### PR TITLE
Added money rounding for availability response

### DIFF
--- a/Api/Infrastructure/Money/MoneyRounder.cs
+++ b/Api/Infrastructure/Money/MoneyRounder.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using HappyTravel.EdoContracts.General.Enums;
+
+namespace HappyTravel.Edo.Api.Infrastructure.Money
+{
+    internal static class MoneyRounder
+    {
+        public static decimal Round(decimal sourceValue, Currencies currency, MidpointRounding rounding = MidpointRounding.AwayFromZero) => Math.Round(sourceValue, CurrencyDecimalDigits[currency], rounding);
+
+        private static readonly Dictionary<Currencies, int> CurrencyDecimalDigits = new Dictionary<Currencies, int>
+        {
+            {Currencies.AED, 2},
+            {Currencies.EUR, 2},
+            {Currencies.SAR, 2},
+            {Currencies.USD, 2}
+        };
+    }
+}

--- a/Api/Services/Accommodations/AvailabilityService.cs
+++ b/Api/Services/Accommodations/AvailabilityService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.FunctionalExtensions;
+using HappyTravel.Edo.Api.Infrastructure.Money;
 using HappyTravel.Edo.Api.Models.Accommodations;
 using HappyTravel.Edo.Api.Models.Customers;
 using HappyTravel.Edo.Api.Models.Markups;
@@ -186,7 +187,13 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
         {
             var markup = await _markupService.Get(customer, MarkupPolicyTarget.AccommodationAvailability);
             var responseWithMarkup = await priceProcessFunc(details, markup.Function);
-            return DataWithMarkup.Create(responseWithMarkup, markup.Policies);
+            var roundedResponse =  await priceProcessFunc(responseWithMarkup, (price, currency) =>
+            {
+                var roundedPrice = MoneyRounder.Round(price, currency);
+                return new ValueTask<(decimal, Currencies)>((roundedPrice, currency));
+            });
+            
+            return DataWithMarkup.Create(roundedResponse, markup.Policies);
         }
 
 


### PR DESCRIPTION
1. Prices from connectors sometimes can come with lots of digits (can be 4 digits for Illusions)
2. Prices that we process during currency conversion and applying markups can have many digits too. 

In this PR I've added money rounding right before returning models from availability service - at markups applying step.
