### PR TITLE
Adding request metadata to method params

### DIFF
--- a/Api/Controllers/AccommodationsController.cs
+++ b/Api/Controllers/AccommodationsController.cs
@@ -28,12 +28,14 @@ namespace HappyTravel.Edo.Api.Controllers
             IAvailabilityService availabilityService,
             IBookingService bookingService,
             IBookingRecordsManager bookingRecordsManager,
+            RequestMetadataProvider requestMetadataProvider,
             IAgentContext agentContext)
         {
             _service = service;
             _availabilityService = availabilityService;
             _bookingService = bookingService;
             _bookingRecordsManager = bookingRecordsManager;
+            _requestMetadataProvider = requestMetadataProvider;
             _agentContext = agentContext;
         }
 
@@ -53,7 +55,7 @@ namespace HappyTravel.Edo.Api.Controllers
             if (string.IsNullOrWhiteSpace(accommodationId))
                 return BadRequest(ProblemDetailsBuilder.Build("No accommodation IDs was provided."));
 
-            var (_, isFailure, response, error) = await _service.Get(source, accommodationId, LanguageCode);
+            var (_, isFailure, response, error) = await _service.Get(source, accommodationId, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -77,7 +79,7 @@ namespace HappyTravel.Edo.Api.Controllers
         public async Task<IActionResult> GetAvailability([FromBody] AvailabilityRequest request)
         {
             var agent = await _agentContext.GetAgent();
-            var (_, isFailure, response, error) = await _availabilityService.GetAvailable(request, agent, LanguageCode);
+            var (_, isFailure, response, error) = await _availabilityService.GetAvailable(request, agent, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -102,7 +104,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationAvailabilitySearch)]
         public async Task<IActionResult> GetAvailabilityForAccommodation([FromRoute] DataProviders source, [FromRoute] string accommodationId, [FromRoute]  string availabilityId)
         {
-            var (_, isFailure, response, error) = await _availabilityService.GetAvailable(source, accommodationId, availabilityId, LanguageCode);
+            var (_, isFailure, response, error) = await _availabilityService.GetAvailable(source, accommodationId, availabilityId, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -124,7 +126,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationAvailabilitySearch)]
         public async Task<IActionResult> GetExactAvailability([FromRoute] DataProviders source, [FromRoute] string availabilityId, [FromRoute] Guid roomContractSetId)
         {
-            var (_, isFailure, availabilityInfo, error) = await _availabilityService.GetExactAvailability(source, availabilityId, roomContractSetId, LanguageCode);
+            var (_, isFailure, availabilityInfo, error) = await _availabilityService.GetExactAvailability(source, availabilityId, roomContractSetId, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -146,7 +148,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationAvailabilitySearch)]
         public async Task<IActionResult> GetDeadline([FromRoute] DataProviders source, [FromRoute] string availabilityId, [FromRoute] Guid roomContractSetId)
         {
-            var (_, isFailure, deadline, error) = await _availabilityService.GetDeadlineDetails(source, availabilityId, roomContractSetId, LanguageCode);
+            var (_, isFailure, deadline, error) = await _availabilityService.GetDeadlineDetails(source, availabilityId, roomContractSetId, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -167,7 +169,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationBooking)]
         public async Task<IActionResult> RegisterBooking([FromBody] AccommodationBookingRequest request)
         {
-            var (_, isFailure, refCode, error) = await _bookingService.Register(request, LanguageCode);
+            var (_, isFailure, refCode, error) = await _bookingService.Register(request, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -188,7 +190,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationBooking)]
         public async Task<IActionResult> FinalizeBooking([FromRoute] string referenceCode)
         {
-            var (_, isFailure, bookingDetails, error) = await _bookingService.Finalize(referenceCode, LanguageCode);
+            var (_, isFailure, bookingDetails, error) = await _bookingService.Finalize(referenceCode, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -208,7 +210,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationBooking)]
         public async Task<IActionResult> RefreshStatus([FromRoute] int bookingId)
         {
-            var (_, isFailure, bookingDetails, error) = await _bookingService.RefreshStatus(bookingId);
+            var (_, isFailure, bookingDetails, error) = await _bookingService.RefreshStatus(bookingId, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -228,7 +230,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [InCounterpartyPermissions(InCounterpartyPermissions.AccommodationBooking)]
         public async Task<IActionResult> CancelBooking(int bookingId)
         {
-            var (_, isFailure, error) = await _bookingService.Cancel(bookingId);
+            var (_, isFailure, error) = await _bookingService.Cancel(bookingId, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(error);
 
@@ -296,6 +298,7 @@ namespace HappyTravel.Edo.Api.Controllers
         private readonly IAvailabilityService _availabilityService;
         private readonly IBookingService _bookingService;
         private readonly IBookingRecordsManager _bookingRecordsManager;
+        private readonly RequestMetadataProvider _requestMetadataProvider;
         private readonly IAgentContext _agentContext;
     }
 }

--- a/Api/Controllers/BookingSupportingDocumentsController.cs
+++ b/Api/Controllers/BookingSupportingDocumentsController.cs
@@ -18,10 +18,12 @@ namespace HappyTravel.Edo.Api.Controllers
     public class BookingSupportingDocumentsController : BaseController
     {
         public BookingSupportingDocumentsController(IBookingMailingService bookingMailingService,
-            IBookingDocumentsService bookingDocumentsService)
+            IBookingDocumentsService bookingDocumentsService,
+            RequestMetadataProvider requestMetadataProvider)
         {
             _bookingMailingService = bookingMailingService;
             _bookingDocumentsService = bookingDocumentsService;
+            _requestMetadataProvider = requestMetadataProvider;
         }
 
 
@@ -36,7 +38,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         public async Task<IActionResult> SendBookingVoucher([Required] int bookingId, [Required][FromBody] SendBookingDocumentRequest sendMailRequest)
         {
-            var (_, isFailure, error) = await _bookingMailingService.SendVoucher(bookingId, sendMailRequest.Email, LanguageCode);
+            var (_, isFailure, error) = await _bookingMailingService.SendVoucher(bookingId, sendMailRequest.Email, _requestMetadataProvider.Get());
             if (isFailure)
                 return BadRequest(ProblemDetailsBuilder.Build(error));
 
@@ -74,7 +76,7 @@ namespace HappyTravel.Edo.Api.Controllers
         [AgentRequired]
         public async Task<IActionResult> GetBookingVoucher([Required] int bookingId)
         {
-            var result = await _bookingDocumentsService.GenerateVoucher(bookingId, LanguageCode);
+            var result = await _bookingDocumentsService.GenerateVoucher(bookingId, _requestMetadataProvider.Get());
             return OkOrBadRequest(result);
         }
 
@@ -96,6 +98,7 @@ namespace HappyTravel.Edo.Api.Controllers
 
 
         private readonly IBookingDocumentsService _bookingDocumentsService;
+        private readonly RequestMetadataProvider _requestMetadataProvider;
         private readonly IBookingMailingService _bookingMailingService;
     }
 }

--- a/Api/Controllers/InternalBookingsController.cs
+++ b/Api/Controllers/InternalBookingsController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Models.Bookings;
 using HappyTravel.Edo.Api.Services.Accommodations;
 using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
@@ -14,9 +15,10 @@ namespace HappyTravel.Edo.Api.Controllers
     [Route("api/{v:apiVersion}/internal/bookings")]
     public class InternalBookingsController : BaseController
     {
-        public InternalBookingsController(IBookingsProcessingService bookingsProcessingService)
+        public InternalBookingsController(IBookingsProcessingService bookingsProcessingService, RequestMetadataProvider requestMetadataProvider)
         {
             _bookingsProcessingService = bookingsProcessingService;
+            _requestMetadataProvider = requestMetadataProvider;
         }
 
 
@@ -40,9 +42,10 @@ namespace HappyTravel.Edo.Api.Controllers
         [HttpPost("cancel")]
         [ProducesResponseType(typeof(ProcessResult), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
-        public async Task<IActionResult> CancelBookings(List<int> bookingIds) => OkOrBadRequest(await _bookingsProcessingService.Cancel(bookingIds));
+        public async Task<IActionResult> CancelBookings(List<int> bookingIds) => OkOrBadRequest(await _bookingsProcessingService.Cancel(bookingIds, _requestMetadataProvider.Get()));
 
 
         private readonly IBookingsProcessingService _bookingsProcessingService;
+        private readonly RequestMetadataProvider _requestMetadataProvider;
     }
 }

--- a/Api/Infrastructure/DataProviders/IDataProviderClient.cs
+++ b/Api/Infrastructure/DataProviders/IDataProviderClient.cs
@@ -4,34 +4,35 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HappyTravel.Edo.Api.Infrastructure.DataProviders
 {
     public interface IDataProviderClient
     {
-        Task<Result<T, ProblemDetails>> Get<T>(Uri url, string languageCode = LocalizationHelper.DefaultLanguageCode,
+        Task<Result<T, ProblemDetails>> Get<T>(Uri url, RequestMetadata requestMetadata,
             CancellationToken cancellationToken = default);
 
 
-        Task<Result<TOut, ProblemDetails>> Post<T, TOut>(Uri url, T requestContent, string languageCode = LocalizationHelper.DefaultLanguageCode,
+        Task<Result<TOut, ProblemDetails>> Post<T, TOut>(Uri url, T requestContent, RequestMetadata requestMetadata,
             CancellationToken cancellationToken = default);
 
 
-        Task<Result<TOut, ProblemDetails>> Post<TOut>(Uri url, string languageCode = LocalizationHelper.DefaultLanguageCode,
+        Task<Result<TOut, ProblemDetails>> Post<TOut>(Uri url, RequestMetadata requestMetadata,
             CancellationToken cancellationToken = default);
         
         
         Task<Result<VoidObject, ProblemDetails>> Post(Uri uri,
-            string languageCode = LocalizationHelper.DefaultLanguageCode,
+            RequestMetadata requestMetadata,
             CancellationToken cancellationToken = default);
 
         
         Task<Result<TOut, ProblemDetails>> Send<TOut>(HttpRequestMessage httpRequestMessage,
-            string languageCode = LocalizationHelper.DefaultLanguageCode, CancellationToken cancellationToken = default);
+            RequestMetadata requestMetadata, CancellationToken cancellationToken = default);
 
 
-        public Task<Result<TOut, ProblemDetails>> Post<TOut>(Uri url, Stream stream, string languageCode = LocalizationHelper.DefaultLanguageCode,
+        public Task<Result<TOut, ProblemDetails>> Post<TOut>(Uri url, Stream stream, RequestMetadata requestMetadata,
             CancellationToken cancellationToken = default);
     }
 }

--- a/Api/Infrastructure/RequestMetadataProvider.cs
+++ b/Api/Infrastructure/RequestMetadataProvider.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+using HappyTravel.Edo.Api.Infrastructure.Http.Extensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
+using Microsoft.AspNetCore.Http;
+
+namespace HappyTravel.Edo.Api.Infrastructure
+{
+    public class RequestMetadataProvider
+    {
+        public RequestMetadataProvider(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+
+        public RequestMetadata Get()
+        {
+            var requestId = _httpContextAccessor.HttpContext.Request.GetRequestId();
+            var languageCode = CultureInfo.CurrentCulture.Name;
+            return new RequestMetadata(requestId, languageCode);
+        }
+        
+        private readonly IHttpContextAccessor _httpContextAccessor;
+    }
+}

--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -448,6 +448,8 @@ namespace HappyTravel.Edo.Api.Infrastructure
 
             services.AddNameNormalizationServices();
             services.AddScoped<ILocationNormalizer, LocationNormalizer>();
+
+            services.AddScoped<RequestMetadataProvider>();
             
             return services;
         }

--- a/Api/Models/Infrastructure/RequestMetadata.cs
+++ b/Api/Models/Infrastructure/RequestMetadata.cs
@@ -1,0 +1,15 @@
+namespace HappyTravel.Edo.Api.Models.Infrastructure
+{
+    public readonly struct RequestMetadata
+    {
+        public RequestMetadata(string requestId, string languageCode)
+        {
+            RequestId = requestId;
+            LanguageCode = languageCode;
+        }
+
+
+        public string RequestId { get; }
+        public string LanguageCode { get; }
+    }
+}

--- a/Api/Services/Accommodations/AccommodationService.cs
+++ b/Api/Services/Accommodations/AccommodationService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using FloxDc.CacheFlow;
 using FloxDc.CacheFlow.Extensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Api.Services.Connectors;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.EdoContracts.Accommodations;
@@ -20,10 +21,10 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
         }
 
 
-        public ValueTask<Result<AccommodationDetails, ProblemDetails>> Get(DataProviders source, string accommodationId, string languageCode)
+        public ValueTask<Result<AccommodationDetails, ProblemDetails>> Get(DataProviders source, string accommodationId, RequestMetadata requestMetadata)
         {
-            return _flow.GetOrSetAsync(_flow.BuildKey(nameof(AccommodationService), "Accommodations", languageCode, accommodationId),
-                async () => await _providerRouter.GetAccommodation(source, accommodationId, languageCode),
+            return _flow.GetOrSetAsync(_flow.BuildKey(nameof(AccommodationService), "Accommodations", requestMetadata.LanguageCode, accommodationId),
+                async () => await _providerRouter.GetAccommodation(source, accommodationId, requestMetadata),
                 TimeSpan.FromDays(1));
         }
 

--- a/Api/Services/Accommodations/Bookings/BookingDocumentsService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingDocumentsService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.Options;
 using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Api.Models.Mailing;
 using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Data.Booking;
@@ -31,14 +32,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         }
 
 
-        public async Task<Result<BookingVoucherData>> GenerateVoucher(int bookingId, string languageCode)
+        public async Task<Result<BookingVoucherData>> GenerateVoucher(int bookingId, RequestMetadata requestMetadata)
         {
             var (_, isBookingFailure, booking, bookingError) = await _bookingRecordsManager.Get(bookingId);
             if (isBookingFailure)
                 return Result.Fail<BookingVoucherData>(bookingError);
 
             var (_, isAccommodationFailure, accommodationDetails, accommodationError) = await _accommodationService.Get(booking.DataProvider, 
-                booking.AccommodationId, languageCode);
+                booking.AccommodationId, requestMetadata);
                 
             if(isAccommodationFailure)
                 return Result.Fail<BookingVoucherData>(accommodationError.Detail);

--- a/Api/Services/Accommodations/Bookings/BookingsProcessingService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingsProcessingService.cs
@@ -8,6 +8,7 @@ using FluentValidation;
 using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Models.Bookings;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Api.Services.Management;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data;
@@ -58,7 +59,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         }
 
 
-        public async Task<Result<ProcessResult>> Cancel(List<int> bookingIds)
+        public async Task<Result<ProcessResult>> Cancel(List<int> bookingIds, RequestMetadata requestMetadata)
         {
             var (_, isUserFailure, _, userError) = await _serviceAccountContext.GetUserInfo();
             if (isUserFailure)
@@ -105,7 +106,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 
                 Task<Result<string>> ProcessBooking(Data.Booking.Booking booking)
                 {
-                    return _bookingService.Cancel(booking.Id)
+                    return _bookingService.Cancel(booking.Id, requestMetadata)
                         .OnBoth(CreateResult);
 
 

--- a/Api/Services/Accommodations/Bookings/IBookingDocumentsService.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingDocumentsService.cs
@@ -1,12 +1,13 @@
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Api.Models.Mailing;
 
 namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 {
     public interface IBookingDocumentsService
     {
-        Task<Result<BookingVoucherData>> GenerateVoucher(int bookingId, string languageCode);
+        Task<Result<BookingVoucherData>> GenerateVoucher(int bookingId, RequestMetadata requestMetadata);
 
         Task<Result<BookingInvoiceData>> GenerateInvoice(int bookingId, string languageCode);
     }

--- a/Api/Services/Accommodations/Bookings/IBookingService.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingService.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Models.Bookings;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,14 +10,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 {
     public interface IBookingService
     {
-        Task<Result<string, ProblemDetails>> Register(AccommodationBookingRequest bookingRequest, string languageCode);
+        Task<Result<string, ProblemDetails>> Register(AccommodationBookingRequest bookingRequest, RequestMetadata requestMetadata);
 
-        Task<Result<BookingDetails, ProblemDetails>> Finalize(string referenceCode, string languageCode);
+        Task<Result<BookingDetails, ProblemDetails>> Finalize(string referenceCode, RequestMetadata requestMetadata);
         
-        Task ProcessResponse(BookingDetails bookingResponse, Data.Booking.Booking booking);
+        Task ProcessResponse(BookingDetails bookingResponse, Data.Booking.Booking booking, RequestMetadata requestMetadata);
 
-        Task<Result<VoidObject, ProblemDetails>> Cancel(int bookingId);
+        Task<Result<VoidObject, ProblemDetails>> Cancel(int bookingId, RequestMetadata requestMetadata);
         
-        Task<Result<BookingDetails, ProblemDetails>> RefreshStatus(int bookingId);
+        Task<Result<BookingDetails, ProblemDetails>> RefreshStatus(int bookingId, RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/Accommodations/Bookings/IBookingsProcessingService.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingsProcessingService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Bookings;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 
 namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 {
@@ -10,6 +11,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
     {
         Task<Result<List<int>>> GetForCancellation(DateTime deadlineDate);
 
-        Task<Result<ProcessResult>> Cancel(List<int> bookingIds);
+        Task<Result<ProcessResult>> Cancel(List<int> bookingIds, RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/Accommodations/IAccommodationService.cs
+++ b/Api/Services/Accommodations/IAccommodationService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
 {
     public interface IAccommodationService
     {
-        ValueTask<Result<AccommodationDetails, ProblemDetails>> Get(DataProviders source, string accommodationId, string languageCode);
+        ValueTask<Result<AccommodationDetails, ProblemDetails>> Get(DataProviders source, string accommodationId, RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/Accommodations/IAvailabilityService.cs
+++ b/Api/Services/Accommodations/IAvailabilityService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Accommodations;
 using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
@@ -11,13 +12,13 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
 {
     public interface IAvailabilityService
     {
-        ValueTask<Result<CombinedAvailabilityDetails, ProblemDetails>> GetAvailable(Models.Availabilities.AvailabilityRequest request, AgentInfo agent, string languageCode);
+        ValueTask<Result<CombinedAvailabilityDetails, ProblemDetails>> GetAvailable(Models.Availabilities.AvailabilityRequest request, AgentInfo agent, RequestMetadata requestMetadata);
 
-        Task<Result<ProviderData<SingleAccommodationAvailabilityDetails>, ProblemDetails>> GetAvailable(DataProviders dataProvider, string accommodationId, string availabilityId, string languageCode);
+        Task<Result<ProviderData<SingleAccommodationAvailabilityDetails>, ProblemDetails>> GetAvailable(DataProviders dataProvider, string accommodationId, string availabilityId, RequestMetadata requestMetadata);
         
         Task<Result<ProviderData<SingleAccommodationAvailabilityDetailsWithDeadline?>, ProblemDetails>> GetExactAvailability(DataProviders dataProvider, string availabilityId, Guid roomContractSetId,
-            string languageCode);
+            RequestMetadata requestMetadata);
 
-        Task<Result<ProviderData<DeadlineDetails>, ProblemDetails>> GetDeadlineDetails(DataProviders dataProvider, string availabilityId, Guid roomContractSetId, string languageCode);
+        Task<Result<ProviderData<DeadlineDetails>, ProblemDetails>> GetDeadlineDetails(DataProviders dataProvider, string availabilityId, Guid roomContractSetId, RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/Connectors/DataProvider.cs
+++ b/Api/Services/Connectors/DataProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Infrastructure.Logging;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -20,94 +21,94 @@ namespace HappyTravel.Edo.Api.Services.Connectors
         }
         
         
-        public Task<Result<AvailabilityDetails, ProblemDetails>> GetAvailability(AvailabilityRequest request, string languageCode)
+        public Task<Result<AvailabilityDetails, ProblemDetails>> GetAvailability(AvailabilityRequest request, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Post<AvailabilityRequest, AvailabilityDetails>(
-                    new Uri(_baseUrl + "accommodations/availabilities", UriKind.Absolute), request, languageCode);
+                    new Uri(_baseUrl + "accommodations/availabilities", UriKind.Absolute), request, requestMetadata);
             });
         }
 
 
         public Task<Result<SingleAccommodationAvailabilityDetails, ProblemDetails>> GetAvailability(string availabilityId,
-            string accommodationId, string languageCode)
+            string accommodationId, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Post<SingleAccommodationAvailabilityDetails>(
-                    new Uri(_baseUrl + "accommodations/" + accommodationId + "/availabilities/" + availabilityId, UriKind.Absolute), languageCode);
+                    new Uri(_baseUrl + "accommodations/" + accommodationId + "/availabilities/" + availabilityId, UriKind.Absolute), requestMetadata);
             });
         }
         
         
-        public Task<Result<SingleAccommodationAvailabilityDetailsWithDeadline?, ProblemDetails>> GetExactAvailability(string availabilityId, Guid roomContractSetId, string languageCode)
+        public Task<Result<SingleAccommodationAvailabilityDetailsWithDeadline?, ProblemDetails>> GetExactAvailability(string availabilityId, Guid roomContractSetId, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Post<SingleAccommodationAvailabilityDetailsWithDeadline?>(
-                    new Uri($"{_baseUrl}accommodations/availabilities/{availabilityId}/room-contract-sets/{roomContractSetId}", UriKind.Absolute), languageCode);
+                    new Uri($"{_baseUrl}accommodations/availabilities/{availabilityId}/room-contract-sets/{roomContractSetId}", UriKind.Absolute), requestMetadata);
             });
         }
 
 
-        public Task<Result<DeadlineDetails, ProblemDetails>> GetDeadline(string availabilityId, Guid roomContractSetId, string languageCode)
+        public Task<Result<DeadlineDetails, ProblemDetails>> GetDeadline(string availabilityId, Guid roomContractSetId, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 var uri = new Uri($"{_baseUrl}accommodations/availabilities/{availabilityId}/room-contract-sets/{roomContractSetId}/deadline", UriKind.Absolute);
-                return _dataProviderClient.Get<DeadlineDetails>(uri, languageCode);
+                return _dataProviderClient.Get<DeadlineDetails>(uri, requestMetadata);
             });
         }
 
 
-        public Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(string accommodationId, string languageCode)
+        public Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(string accommodationId, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Get<AccommodationDetails>(
-                    new Uri($"{_baseUrl}accommodations/{accommodationId}", UriKind.Absolute), languageCode);
+                    new Uri($"{_baseUrl}accommodations/{accommodationId}", UriKind.Absolute), requestMetadata);
             });
         }
 
 
-        public Task<Result<BookingDetails, ProblemDetails>> Book(BookingRequest request, string languageCode)
+        public Task<Result<BookingDetails, ProblemDetails>> Book(BookingRequest request, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Post<BookingRequest, BookingDetails>(
                     new Uri(_baseUrl + "accommodations/bookings", UriKind.Absolute),
-                    request, languageCode);
+                    request, requestMetadata);
             });
         }
 
 
-        public Task<Result<VoidObject, ProblemDetails>> CancelBooking(string referenceCode)
+        public Task<Result<VoidObject, ProblemDetails>> CancelBooking(string referenceCode, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Post(new Uri(_baseUrl + "accommodations/bookings/" + referenceCode + "/cancel",
-                    UriKind.Absolute));
+                    UriKind.Absolute), requestMetadata);
             });
         }
 
 
-        public Task<Result<BookingDetails, ProblemDetails>> GetBookingDetails(string referenceCode, string languageCode)
+        public Task<Result<BookingDetails, ProblemDetails>> GetBookingDetails(string referenceCode, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
                 return _dataProviderClient.Get<BookingDetails>(
                     new Uri(_baseUrl + "accommodations/bookings/" + referenceCode,
-                        UriKind.Absolute), languageCode);
+                        UriKind.Absolute), requestMetadata);
             });
         }
 
 
-        public Task<Result<BookingDetails, ProblemDetails>> ProcessAsyncResponse(Stream stream)
+        public Task<Result<BookingDetails, ProblemDetails>> ProcessAsyncResponse(Stream stream, RequestMetadata requestMetadata)
         {
             return ExecuteWithLogging(() =>
             {
-                return _dataProviderClient.Post<BookingDetails>(new Uri(_baseUrl + "bookings/response", UriKind.Absolute), stream);
+                return _dataProviderClient.Post<BookingDetails>(new Uri(_baseUrl + "bookings/response", UriKind.Absolute), stream, requestMetadata);
             });
         }
         

--- a/Api/Services/Connectors/IDataProvider.cs
+++ b/Api/Services/Connectors/IDataProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,24 +11,24 @@ namespace HappyTravel.Edo.Api.Services.Connectors
 {
     public interface IDataProvider
     {
-        Task<Result<AvailabilityDetails, ProblemDetails>> GetAvailability(AvailabilityRequest availabilityRequest, string languageCode);
+        Task<Result<AvailabilityDetails, ProblemDetails>> GetAvailability(AvailabilityRequest availabilityRequest, RequestMetadata requestMetadata);
 
         Task<Result<SingleAccommodationAvailabilityDetails, ProblemDetails>> GetAvailability(string availabilityId,
-            string accommodationId, string languageCode);
+            string accommodationId, RequestMetadata requestMetadata);
         
-        Task<Result<SingleAccommodationAvailabilityDetailsWithDeadline?, ProblemDetails>> GetExactAvailability(string availabilityId, Guid roomContractSetId,
-            string languageCode);
+        Task<Result<SingleAccommodationAvailabilityDetailsWithDeadline?, ProblemDetails>> GetExactAvailability(string availabilityId, Guid roomContractSetId, 
+            RequestMetadata requestMetadata);
 
-        Task<Result<DeadlineDetails, ProblemDetails>> GetDeadline(string availabilityId, Guid roomContractSetId, string languageCode);
+        Task<Result<DeadlineDetails, ProblemDetails>> GetDeadline(string availabilityId, Guid roomContractSetId, RequestMetadata requestMetadata);
 
-        Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(string accommodationId, string languageCode);
+        Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(string accommodationId, RequestMetadata requestMetadata);
 
-        Task<Result<BookingDetails, ProblemDetails>>  Book(BookingRequest request, string languageCode);
+        Task<Result<BookingDetails, ProblemDetails>>  Book(BookingRequest request, RequestMetadata requestMetadata);
 
-        Task<Result<VoidObject, ProblemDetails>> CancelBooking(string referenceCode);
+        Task<Result<VoidObject, ProblemDetails>> CancelBooking(string referenceCode, RequestMetadata requestMetadata);
 
-        Task<Result<BookingDetails, ProblemDetails>> GetBookingDetails(string referenceCode, string languageCode);
+        Task<Result<BookingDetails, ProblemDetails>> GetBookingDetails(string referenceCode, RequestMetadata requestMetadata);
 
-        Task<Result<BookingDetails, ProblemDetails>> ProcessAsyncResponse(Stream stream);
+        Task<Result<BookingDetails, ProblemDetails>> ProcessAsyncResponse(Stream stream, RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/Connectors/IProviderRouter.cs
+++ b/Api/Services/Connectors/IProviderRouter.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Models.Accommodations;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
@@ -13,27 +14,27 @@ namespace HappyTravel.Edo.Api.Services.Connectors
     public interface IProviderRouter
     {
         Task<Result<CombinedAvailabilityDetails>> GetAvailability(List<DataProviders> dataProviders, AvailabilityRequest availabilityRequest,
-            string languageCode);
+            RequestMetadata requestMetadata);
 
 
         Task<Result<SingleAccommodationAvailabilityDetails, ProblemDetails>> GetAvailable(DataProviders dataProvider, string accommodationId,
-            string availabilityId, string languageCode);
+            string availabilityId, RequestMetadata requestMetadata);
 
 
         Task<Result<SingleAccommodationAvailabilityDetailsWithDeadline?, ProblemDetails>> GetExactAvailability(DataProviders dataProvider, string availabilityId,
-            Guid roomContractSetId, string languageCode);
+            Guid roomContractSetId, RequestMetadata requestMetadata);
 
 
-        Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(DataProviders dataProvider, string id, string languageCode);
+        Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(DataProviders dataProvider, string id, RequestMetadata requestMetadata);
 
-        Task<Result<BookingDetails, ProblemDetails>> Book(DataProviders dataProvider, BookingRequest request, string languageCode);
+        Task<Result<BookingDetails, ProblemDetails>> Book(DataProviders dataProvider, BookingRequest request, RequestMetadata requestMetadata);
 
-        Task<Result<VoidObject, ProblemDetails>> CancelBooking(DataProviders dataProvider, string referenceCode);
+        Task<Result<VoidObject, ProblemDetails>> CancelBooking(DataProviders dataProvider, string referenceCode, RequestMetadata requestMetadata);
 
-        Task<Result<DeadlineDetails,ProblemDetails>> GetDeadline(DataProviders dataProvider, string availabilityId, Guid roomContractSetId, string languageCode);
+        Task<Result<DeadlineDetails,ProblemDetails>> GetDeadline(DataProviders dataProvider, string availabilityId, Guid roomContractSetId, RequestMetadata requestMetadata);
 
 
         Task<Result<BookingDetails, ProblemDetails>> GetBookingDetails(DataProviders dataProvider, string referenceCode,
-            string languageCode);
+            RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/Connectors/ProviderRouter.cs
+++ b/Api/Services/Connectors/ProviderRouter.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Models.Accommodations;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
@@ -19,7 +20,7 @@ namespace HappyTravel.Edo.Api.Services.Connectors
         }
 
 
-        public async Task<Result<CombinedAvailabilityDetails>> GetAvailability(List<DataProviders> dataProviders, AvailabilityRequest availabilityRequest, string languageCode)
+        public async Task<Result<CombinedAvailabilityDetails>> GetAvailability(List<DataProviders> dataProviders, AvailabilityRequest availabilityRequest, RequestMetadata requestMetadata)
         {
             var results = await GetResultsFromConnectors();
 
@@ -53,7 +54,7 @@ namespace HappyTravel.Edo.Api.Services.Connectors
 
                 var getAvailabilityTasks = providers.Select(async providerInfo =>
                 {
-                    var result = await providerInfo.Provider.GetAvailability(availabilityRequest, languageCode);
+                    var result = await providerInfo.Provider.GetAvailability(availabilityRequest, requestMetadata);
                     return (providerInfo.Key, result);
                 }).ToList();
 
@@ -67,55 +68,55 @@ namespace HappyTravel.Edo.Api.Services.Connectors
 
 
         public Task<Result<SingleAccommodationAvailabilityDetails, ProblemDetails>> GetAvailable(DataProviders dataProvider, string accommodationId,
-            string availabilityId, string languageCode)
+            string availabilityId, RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.GetAvailability(availabilityId, accommodationId, languageCode);
+            return provider.GetAvailability(availabilityId, accommodationId, requestMetadata);
         }
 
 
         public Task<Result<SingleAccommodationAvailabilityDetailsWithDeadline?, ProblemDetails>> GetExactAvailability(DataProviders dataProvider,
-            string availabilityId, Guid roomContractSetId, string languageCode)
+            string availabilityId, Guid roomContractSetId, RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.GetExactAvailability(availabilityId, roomContractSetId, languageCode);
+            return provider.GetExactAvailability(availabilityId, roomContractSetId, requestMetadata);
         }
 
 
-        public Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(DataProviders dataProvider, string id, string languageCode)
+        public Task<Result<AccommodationDetails, ProblemDetails>> GetAccommodation(DataProviders dataProvider, string id, RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.GetAccommodation(id, languageCode);
+            return provider.GetAccommodation(id, requestMetadata);
         }
 
 
-        public Task<Result<BookingDetails, ProblemDetails>> Book(DataProviders dataProvider, BookingRequest request, string languageCode)
+        public Task<Result<BookingDetails, ProblemDetails>> Book(DataProviders dataProvider, BookingRequest request, RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.Book(request, languageCode);
+            return provider.Book(request, requestMetadata);
         }
 
 
-        public Task<Result<VoidObject, ProblemDetails>> CancelBooking(DataProviders dataProvider, string referenceCode)
+        public Task<Result<VoidObject, ProblemDetails>> CancelBooking(DataProviders dataProvider, string referenceCode, RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.CancelBooking(referenceCode);
+            return provider.CancelBooking(referenceCode, requestMetadata);
         }
 
 
         public Task<Result<DeadlineDetails, ProblemDetails>> GetDeadline(DataProviders dataProvider, string availabilityId,
-            Guid roomContractSetId, string languageCode)
+            Guid roomContractSetId, RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.GetDeadline(availabilityId, roomContractSetId, languageCode);
+            return provider.GetDeadline(availabilityId, roomContractSetId, requestMetadata);
         }
         
         
         public Task<Result<BookingDetails, ProblemDetails>> GetBookingDetails(DataProviders dataProvider, string referenceCode,
-            string languageCode)
+            RequestMetadata requestMetadata)
         {
             var provider = _dataProviderFactory.Get(dataProvider);
-            return provider.GetBookingDetails(referenceCode, languageCode);
+            return provider.GetBookingDetails(referenceCode, requestMetadata);
         }
 
 

--- a/Api/Services/CurrencyConversion/CurrencyConverterService.cs
+++ b/Api/Services/CurrencyConversion/CurrencyConverterService.cs
@@ -58,6 +58,7 @@ namespace HappyTravel.Edo.Api.Services.CurrencyConversion
             
             ValueTask<Currencies> GetTargetCurrency(AgentInfo agentInfo)
             {
+                return new ValueTask<Currencies>(Currencies.USD);
                 var key = _memoryFlow.BuildKey(nameof(CurrencyConverterService), "TARGET_CURRENCY", agentInfo.AgentId.ToString());
                 return _memoryFlow.GetOrSetAsync(key, async () =>
                 {

--- a/Api/Services/Mailing/BookingMailingService.cs
+++ b/Api/Services/Mailing/BookingMailingService.cs
@@ -5,6 +5,7 @@ using CSharpFunctionalExtensions;
 using FluentValidation;
 using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.Options;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
 using HappyTravel.MailSender;
 using HappyTravel.MailSender.Formatters;
@@ -25,9 +26,9 @@ namespace HappyTravel.Edo.Api.Services.Mailing
         }
 
 
-        public Task<Result> SendVoucher(int bookingId, string email, string languageCode)
+        public Task<Result> SendVoucher(int bookingId, string email, RequestMetadata requestMetadata)
         {
-            return _bookingDocumentsService.GenerateVoucher(bookingId, languageCode)
+            return _bookingDocumentsService.GenerateVoucher(bookingId, requestMetadata)
                 .OnSuccess(voucher =>
                 {
                     var voucherData = new

--- a/Api/Services/Mailing/IBookingMailingService.cs
+++ b/Api/Services/Mailing/IBookingMailingService.cs
@@ -1,11 +1,12 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 
 namespace HappyTravel.Edo.Api.Services.Mailing
 {
     public interface IBookingMailingService
     {
-        Task<Result> SendVoucher(int bookingId, string email, string languageCode);
+        Task<Result> SendVoucher(int bookingId, string email, RequestMetadata requestMetadata);
 
         Task<Result> SendInvoice(int bookingId, string email, string languageCode);
 

--- a/Api/Services/ProviderResponses/BookingWebhookResponseService.cs
+++ b/Api/Services/ProviderResponses/BookingWebhookResponseService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
 using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Api.Services.Connectors;
@@ -24,13 +25,13 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
         }
         
         
-        public async Task<Result> ProcessBookingData(Stream stream, DataProviders dataProvider)
+        public async Task<Result> ProcessBookingData(Stream stream, DataProviders dataProvider, RequestMetadata requestMetadata)
         {
             if (!AsyncDataProviders.Contains(dataProvider))
                 return Result.Fail($"{nameof(dataProvider)} '{dataProvider}' isn't asynchronous." +
                     $"Asynchronous data providers: {string.Join(", ", AsyncDataProviders)}");
             
-            var (_, isGettingBookingDetailsFailure, bookingDetails, gettingBookingDetailsError) = await _dataProviderFactory.Get(dataProvider).ProcessAsyncResponse(stream);
+            var (_, isGettingBookingDetailsFailure, bookingDetails, gettingBookingDetailsError) = await _dataProviderFactory.Get(dataProvider).ProcessAsyncResponse(stream, requestMetadata);
             if (isGettingBookingDetailsFailure)
                 return Result.Fail(gettingBookingDetailsError.Detail);
             
@@ -41,7 +42,7 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
             
             await _agentContext.SetAgentInfo(booking.AgentId);
             
-            await _bookingService.ProcessResponse(bookingDetails, booking);
+            await _bookingService.ProcessResponse(bookingDetails, booking, requestMetadata);
             return Result.Ok();
         }
 

--- a/Api/Services/ProviderResponses/IBookingWebhookResponseService.cs
+++ b/Api/Services/ProviderResponses/IBookingWebhookResponseService.cs
@@ -1,12 +1,13 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 using HappyTravel.Edo.Common.Enums;
 
 namespace HappyTravel.Edo.Api.Services.ProviderResponses
 {
     public interface IBookingWebhookResponseService
     {
-        Task<Result> ProcessBookingData(Stream requestBody, DataProviders dataProvider);
+        Task<Result> ProcessBookingData(Stream requestBody, DataProviders dataProvider, RequestMetadata requestMetadata);
     }
 }

--- a/Api/Services/ProviderResponses/INetstormingResponseService.cs
+++ b/Api/Services/ProviderResponses/INetstormingResponseService.cs
@@ -1,12 +1,11 @@
-﻿using System.IO;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
-using Microsoft.AspNetCore.Mvc;
+using HappyTravel.Edo.Api.Models.Infrastructure;
 
 namespace HappyTravel.Edo.Api.Services.ProviderResponses
 {
     public interface INetstormingResponseService
     {
-        Task<Result> ProcessBookingDetailsResponse(byte[] xmlRequestData);
+        Task<Result> ProcessBookingDetailsResponse(byte[] xmlRequestData, RequestMetadata requestMetadata);
     }
 }


### PR DESCRIPTION
We use request ids to trace and log requests through all our services.
In previous version it was generated inside a dataprovider client with using HttpContextAccessor.
In new version there is a new model: RequestMetadata, which contains language code and request id and should be passed to methods explicitly.
This allows us to use this functionality in async use cases.