### PR TITLE
Fixed unhandled error for empty availability results + added logging

### DIFF
--- a/Api/Infrastructure/Logging/LoggerEvents.cs
+++ b/Api/Infrastructure/Logging/LoggerEvents.cs
@@ -36,6 +36,7 @@
         MultiProviderAvailabilitySearchStarted = 1140,
         ProviderAvailabilitySearchStarted = 1141,
         ProviderAvailabilitySearchSuccess = 1142,
-        ProviderAvailabilitySearchFailure = 1143
+        ProviderAvailabilitySearchFailure = 1143,
+        ProviderAvailabilitySearchException = 1145
     }
 }

--- a/Api/Infrastructure/Logging/LoggerExtensions.cs
+++ b/Api/Infrastructure/Logging/LoggerExtensions.cs
@@ -145,6 +145,10 @@ namespace HappyTravel.Edo.Api.Infrastructure.Logging
             AvailabilityProviderSearchFailedEventOccured = LoggerMessage.Define<string>(LogLevel.Error,
                 new EventId((int) LoggerEvents.ProviderAvailabilitySearchFailure, LoggerEvents.ProviderAvailabilitySearchFailure.ToString()),
                 $"ERROR | {nameof(AvailabilitySearchScheduler)}: {{message}}");
+            
+            AvailabilityProviderSearchExceptionOccured = LoggerMessage.Define<string>(LogLevel.Critical,
+                new EventId((int) LoggerEvents.ProviderAvailabilitySearchException, LoggerEvents.ProviderAvailabilitySearchException.ToString()),
+                $"EXCEPTION | {nameof(AvailabilitySearchScheduler)}: {{message}}");
         }
 
 
@@ -252,6 +256,9 @@ namespace HappyTravel.Edo.Api.Infrastructure.Logging
         internal static void LogAvailabilityProviderSearchTaskFinishedError(this ILogger logger, string message)
             => AvailabilityProviderSearchFailedEventOccured(logger, message, null);
         
+        internal static void LogAvailabilityProviderSearchTaskFinishedException(this ILogger logger, string message, Exception exception)
+            => AvailabilityProviderSearchExceptionOccured(logger, message, exception);
+        
         private static readonly Action<ILogger, Exception> DataProviderClientExceptionOccurred;
         private static readonly Action<ILogger, string, Exception> DataProviderRequestErrorOccurred;
         private static readonly Action<ILogger, Exception> GeoCoderExceptionOccurred;
@@ -290,5 +297,6 @@ namespace HappyTravel.Edo.Api.Infrastructure.Logging
         private static readonly Action<ILogger, string, Exception> AvailabilityProviderSearchStartedEventOccured;
         private static readonly Action<ILogger, string, Exception> AvailabilityProviderSearchSuccessEventOccured;
         private static readonly Action<ILogger, string, Exception> AvailabilityProviderSearchFailedEventOccured;
+        private static readonly Action<ILogger, string, Exception> AvailabilityProviderSearchExceptionOccured;
     }
 }

--- a/Api/Services/Accommodations/Availability/AvailabilityResultsExtensions.cs
+++ b/Api/Services/Accommodations/Availability/AvailabilityResultsExtensions.cs
@@ -131,20 +131,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability
         }
 
 
-        public static Currencies? GetCurrency(this CombinedAvailabilityDetails availabilityDetails)
-        {
-            var roomContractSets = availabilityDetails.Results
-                .SelectMany(r => r.Data.RoomContractSets)
-                .ToList();
-
-            if (!roomContractSets.Any())
-                return null;
-            
-            return roomContractSets
-                .Select(a => a.Price.Currency)
-                .First();
-        }
-        
         public static Currencies? GetCurrency(this SingleAccommodationAvailabilityDetails availabilityDetails)
         {
             if (!availabilityDetails.RoomContractSets.Any())
@@ -177,7 +163,10 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability
 
         public static Currencies? GetCurrency(AvailabilityDetails details)
         {
-            return details.Results.FirstOrDefault().RoomContractSets.FirstOrDefault().Price.Currency;
+            if (!details.Results.Any())
+                return null;
+            
+            return details.Results.First().RoomContractSets.First().Price.Currency;
         }
     }
 }


### PR DESCRIPTION
This could cause availability search tasks to have state 'PartiallyCompleted' always