### PR TITLE
Batch booking money capture

### DIFF
--- a/Api/Controllers/InternalBookingsController.cs
+++ b/Api/Controllers/InternalBookingsController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
@@ -60,8 +61,13 @@ namespace HappyTravel.Edo.Api.Controllers
         [ProducesResponseType(typeof(List<int>), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [ServiceAccountRequired]
-        public async Task<IActionResult> GetBookingsForCapture(DateTime deadlineDate)
-            => OkOrBadRequest(await _bookingsProcessingService.GetForCapture(deadlineDate));
+        public async Task<IActionResult> GetBookingsForCapture(DateTime? deadlineDate)
+        {
+            if (!deadlineDate.HasValue)
+                return BadRequest($"Deadline date should be specified");
+            
+            return Ok(await _bookingsProcessingService.GetForCapture(deadlineDate.Value));
+        }
 
 
         /// <summary>
@@ -89,7 +95,13 @@ namespace HappyTravel.Edo.Api.Controllers
         [ProducesResponseType(typeof(List<int>), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [ServiceAccountRequired]
-        public async Task<IActionResult> GetBookingsToNotify(DateTime deadlineDate) => OkOrBadRequest(await _bookingsProcessingService.GetForNotification(deadlineDate));
+        public async Task<IActionResult> GetBookingsToNotify(DateTime? deadlineDate)
+        {
+            if (!deadlineDate.HasValue)
+                return BadRequest($"Deadline date should be specified");
+            
+            return Ok(await _bookingsProcessingService.GetForNotification(deadlineDate.Value));
+        }
 
 
         /// <summary>

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -343,7 +343,7 @@
             <param name="bookingIds">List of booking ids for cancellation</param>
             <returns>Result message</returns>
         </member>
-        <member name="M:HappyTravel.Edo.Api.Controllers.InternalBookingsController.GetBookingsForCapture(System.DateTime)">
+        <member name="M:HappyTravel.Edo.Api.Controllers.InternalBookingsController.GetBookingsForCapture(System.Nullable{System.DateTime})">
             <summary>
                 Gets bookings for payment completion by deadline date
             </summary>
@@ -357,7 +357,7 @@
             <param name="bookingIds">List of booking ids for capture</param>
             <returns>Result message</returns>
         </member>
-        <member name="M:HappyTravel.Edo.Api.Controllers.InternalBookingsController.GetBookingsToNotify(System.DateTime)">
+        <member name="M:HappyTravel.Edo.Api.Controllers.InternalBookingsController.GetBookingsToNotify(System.Nullable{System.DateTime})">
             <summary>
                 Sends need payment notifications for bookings
             </summary>

--- a/Api/Services/Accommodations/Bookings/BookingsProcessingService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingsProcessingService.cs
@@ -27,13 +27,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         public BookingsProcessingService(IBookingPaymentService bookingPaymentService,
             IPaymentNotificationService notificationService,
             IBookingService bookingService,
-            IDateTimeProvider dateTimeProvider,
             EdoContext context)
         {
             _bookingPaymentService = bookingPaymentService;
             _notificationService = notificationService;
             _bookingService = bookingService;
-            _dateTimeProvider = dateTimeProvider;
             _context = context;
         }
 
@@ -210,7 +208,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         private readonly IBookingPaymentService _bookingPaymentService;
         private readonly IBookingService _bookingService;
         private readonly EdoContext _context;
-        private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IPaymentNotificationService _notificationService;
     }
 }

--- a/Api/Services/Accommodations/Bookings/IBookingsProcessingService.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingsProcessingService.cs
@@ -9,11 +9,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 {
     public interface IBookingsProcessingService
     {
-        Task<Result<List<int>>> GetForCapture(DateTime deadlineDate);
+        Task<List<int>> GetForCapture(DateTime date);
 
         Task<Result<ProcessResult>> Capture(List<int> bookingIds, ServiceAccount serviceAccount);
         
-        Task<Result<List<int>>> GetForNotification(DateTime deadlineDate);
+        Task<List<int>> GetForNotification(DateTime date);
 
         Task<Result<ProcessResult>> NotifyDeadlineApproaching(List<int> bookingIds, ServiceAccount serviceAccount);
 

--- a/HappyTravel.Edo.UnitTests/Bookings/Processing/Cancellation/ExecutingCancellation.cs
+++ b/HappyTravel.Edo.UnitTests/Bookings/Processing/Cancellation/ExecutingCancellation.cs
@@ -62,7 +62,10 @@ namespace HappyTravel.Edo.UnitTests.Bookings.Processing.Cancellation
             context.Setup(c => c.Bookings)
                 .Returns(DbSetMockProvider.GetDbSetMock(Bookings));
 
-            var service = new BookingsProcessingService(Mock.Of<IBookingPaymentService>(), Mock.Of<IPaymentNotificationService>(), bookingService, new DefaultDateTimeProvider(), context.Object);
+            var service = new BookingsProcessingService(Mock.Of<IBookingPaymentService>(), 
+                Mock.Of<IPaymentNotificationService>(),
+                bookingService, 
+                context.Object);
             return service;
         }
 

--- a/HappyTravel.Edo.UnitTests/Bookings/Processing/Cancellation/GettingForCancellation.cs
+++ b/HappyTravel.Edo.UnitTests/Bookings/Processing/Cancellation/GettingForCancellation.cs
@@ -86,10 +86,11 @@ namespace HappyTravel.Edo.UnitTests.Bookings.Processing.Cancellation
             context
                 .Setup(c => c.Bookings)
                 .Returns(DbSetMockProvider.GetDbSetMock(Bookings));
-            
+
             return new BookingsProcessingService(Mock.Of<IBookingPaymentService>(),
-                Mock.Of<IPaymentNotificationService>(), Mock.Of<IBookingService>()
-                , new DefaultDateTimeProvider(), context.Object);
+                Mock.Of<IPaymentNotificationService>(),
+                Mock.Of<IBookingService>(),
+                context.Object);
         }
 
         

--- a/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/ExecutingCapturing.cs
+++ b/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/ExecutingCapturing.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Models.Users;
+using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
+using HappyTravel.Edo.Api.Services.Payments;
+using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Edo.Data.Booking;
+using HappyTravel.Edo.Data.Management;
+using HappyTravel.Edo.UnitTests.Infrastructure;
+using HappyTravel.Edo.UnitTests.Infrastructure.DbSetMocks;
+using HappyTravel.EdoContracts.Accommodations.Enums;
+using HappyTravel.EdoContracts.General.Enums;
+using Moq;
+using Xunit;
+
+namespace HappyTravel.Edo.UnitTests.Bookings.Processing.Capturing
+{
+    public class ExecutingCapturing
+    {
+        [Fact]
+        public async Task Capture_valid_bookings_should_succeed()
+        {
+            var service = CreateProcessingService(Mock.Of<IBookingPaymentService>());
+
+            var (isSuccess, _, _, _) = await service.Capture(new List<int> {1, 2}, ServiceAccount);
+
+            Assert.True(isSuccess);
+        }
+        
+        
+        [Fact]
+        public async Task Capture_invalid_booking_should_fail()
+        {
+            var service = CreateProcessingService(Mock.Of<IBookingPaymentService>());
+
+            var (_, isFailure, _, _) = await service.Capture(new List<int> {4, 5}, ServiceAccount);
+
+            Assert.True(isFailure);
+        }
+        
+        
+        [Fact]
+        public async Task All_bookings_should_be_captured()
+        {
+            var bookingServiceMock = new Mock<IBookingPaymentService>();
+            var service = CreateProcessingService(bookingServiceMock.Object);
+
+            await service.Capture(new List<int> {1, 2, 3}, ServiceAccount);
+
+            bookingServiceMock
+                .Verify(
+                    b => b.CaptureMoney(It.IsAny<Booking>(), It.IsAny<UserInfo>()),
+                    Times.Exactly(3)
+                );
+        }
+
+
+        private BookingsProcessingService CreateProcessingService(IBookingPaymentService bookingPaymentService)
+        {
+            var context = MockEdoContext.Create();
+            context.Setup(c => c.Bookings)
+                .Returns(DbSetMockProvider.GetDbSetMock(Bookings));
+            
+            var dateTimeProviderMock = new Mock<IDateTimeProvider>();
+            dateTimeProviderMock
+                .Setup(d => d.UtcNow())
+                .Returns(Date);
+
+            var service = new BookingsProcessingService(bookingPaymentService,
+                Mock.Of<IPaymentNotificationService>(),
+                Mock.Of<IBookingService>(), 
+                new DefaultDateTimeProvider(),
+                context.Object);
+            return service;
+        }
+
+
+        private static readonly DateTime Date = new DateTime(2021, 12, 10, 10, 12, 57);
+        
+        private static readonly ServiceAccount ServiceAccount = new ServiceAccount { ClientId = "ClientId", Id = 11};
+
+        private static readonly Booking[] Bookings =
+        {
+            new Booking
+            {
+                Id = 1, 
+                PaymentStatus = BookingPaymentStatuses.Authorized, 
+                ReferenceCode = "NNN-222",
+                Status = BookingStatusCodes.Pending,
+                PaymentMethod = PaymentMethods.BankTransfer,
+                CheckInDate = new DateTime(2021, 12, 10)
+            },
+            new Booking
+            {
+                Id = 2, 
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                ReferenceCode = "NNN-223", 
+                Status = BookingStatusCodes.Confirmed, 
+                PaymentMethod = PaymentMethods.CreditCard,
+                CheckInDate = new DateTime(2021, 12, 11),
+                DeadlineDate = new DateTime(2021, 12, 9)
+            },
+            new Booking
+            {
+                Id = 3,
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                ReferenceCode = "NNN-224",
+                Status = BookingStatusCodes.Confirmed,
+                PaymentMethod = PaymentMethods.CreditCard,
+                CheckInDate = new DateTime(2021, 12, 10),
+                DeadlineDate = new DateTime(2021, 11, 9)
+            },
+            new Booking
+            {
+                Id = 4,
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                ReferenceCode = "NNN-224",
+                Status = BookingStatusCodes.Cancelled,
+                PaymentMethod = PaymentMethods.BankTransfer,
+                CheckInDate = new DateTime(2021, 12, 20)
+            },
+            new Booking
+            {
+                Id = 5,
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                ReferenceCode = "NNN-224",
+                Status = BookingStatusCodes.Rejected,
+                PaymentMethod = PaymentMethods.BankTransfer,
+                CheckInDate = new DateTime(2022, 12, 20)
+            }
+        };
+        
+        
+    }
+}

--- a/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/ExecutingCapturing.cs
+++ b/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/ExecutingCapturing.cs
@@ -64,22 +64,14 @@ namespace HappyTravel.Edo.UnitTests.Bookings.Processing.Capturing
             context.Setup(c => c.Bookings)
                 .Returns(DbSetMockProvider.GetDbSetMock(Bookings));
             
-            var dateTimeProviderMock = new Mock<IDateTimeProvider>();
-            dateTimeProviderMock
-                .Setup(d => d.UtcNow())
-                .Returns(Date);
-
             var service = new BookingsProcessingService(bookingPaymentService,
                 Mock.Of<IPaymentNotificationService>(),
                 Mock.Of<IBookingService>(), 
-                new DefaultDateTimeProvider(),
                 context.Object);
             return service;
         }
 
 
-        private static readonly DateTime Date = new DateTime(2021, 12, 10, 10, 12, 57);
-        
         private static readonly ServiceAccount ServiceAccount = new ServiceAccount { ClientId = "ClientId", Id = 11};
 
         private static readonly Booking[] Bookings =

--- a/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/GettingForCapturing.cs
+++ b/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/GettingForCapturing.cs
@@ -196,7 +196,6 @@ namespace HappyTravel.Edo.UnitTests.Bookings.Processing.Capturing
             var service = new BookingsProcessingService(Mock.Of<IBookingPaymentService>(),
                 Mock.Of<IPaymentNotificationService>(),
                 Mock.Of<IBookingService>(),
-                new DefaultDateTimeProvider(),
                 context.Object);
             
             return service;

--- a/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/GettingForCapturing.cs
+++ b/HappyTravel.Edo.UnitTests/Bookings/Processing/Capturing/GettingForCapturing.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
+using HappyTravel.Edo.Api.Services.Payments;
+using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Edo.Data.Booking;
+using HappyTravel.Edo.UnitTests.Infrastructure;
+using HappyTravel.Edo.UnitTests.Infrastructure.DbSetMocks;
+using HappyTravel.EdoContracts.Accommodations.Enums;
+using HappyTravel.EdoContracts.General.Enums;
+using Moq;
+using Xunit;
+
+namespace HappyTravel.Edo.UnitTests.Bookings.Processing.Capturing
+{
+    public class GettingForCapturing
+    {
+        [Fact]
+        public async Task Should_return_bookings_within_given_deadline()
+        {
+            var date = new DateTime(2021, 12, 3);
+            var bookings = new []
+            {
+                CreateBooking(id: 1, deadlineDate: new DateTime(2021, 12, 1)),
+                CreateBooking(id: 2, deadlineDate: new DateTime(2021, 12, 2)),
+                CreateBooking(id: 3, deadlineDate: new DateTime(2021, 12, 3)),
+                CreateBooking(id: 4, deadlineDate: new DateTime(2021, 12, 4)),
+                CreateBooking(id: 5, deadlineDate: null)
+            };
+            var service = CreateProcessingService(bookings);
+
+            var bookingsToCapture = await service.GetForCapture(date);
+
+            Assert.Contains(1, bookingsToCapture);
+            Assert.Contains(2, bookingsToCapture);
+            Assert.Contains(3, bookingsToCapture);
+            Assert.DoesNotContain(4, bookingsToCapture);
+            Assert.DoesNotContain(5, bookingsToCapture);
+
+            static Booking CreateBooking(int id, DateTime? deadlineDate) => new Booking
+            {
+                Id = id, 
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                Status = BookingStatusCodes.Confirmed,
+                PaymentMethod = PaymentMethods.BankTransfer,
+                DeadlineDate = deadlineDate,
+                CheckInDate = DateTime.MaxValue
+            };
+        }
+        
+        
+        [Fact]
+        public async Task Should_return_bookings_within_given_checkin_date()
+        {
+            var date = new DateTime(2021, 12, 2);
+            var bookings = new []
+            {
+                CreateBooking(id: 1, checkInDate: new DateTime(2021, 12, 1)),
+                CreateBooking(id: 2, checkInDate: new DateTime(2021, 12, 2)),
+                CreateBooking(id: 3, checkInDate: new DateTime(2021, 12, 3)),
+                CreateBooking(id: 4, checkInDate: new DateTime(2021, 12, 4)),
+            };
+            var service = CreateProcessingService(bookings);
+
+            var bookingsToCapture = await service.GetForCapture(date);
+
+            Assert.Contains(1, bookingsToCapture);
+            Assert.Contains(2, bookingsToCapture);
+            Assert.DoesNotContain(3, bookingsToCapture);
+            Assert.DoesNotContain(4, bookingsToCapture);
+
+            static Booking CreateBooking(int id, DateTime checkInDate) => new Booking
+            {
+                Id = id, 
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                Status = BookingStatusCodes.Confirmed,
+                PaymentMethod = PaymentMethods.BankTransfer,
+                DeadlineDate = null,
+                CheckInDate = checkInDate
+            };
+        }
+        
+        
+        [Fact]
+        public async Task Should_return_bookings_within_valid_payment_methods()
+        {
+            var date = new DateTime(2021, 12, 2);
+            var bookings = new []
+            {
+                CreateBooking(id: 1, paymentMethod: PaymentMethods.Offline),
+                CreateBooking(id: 2, paymentMethod: PaymentMethods.Other),
+                CreateBooking(id: 3, paymentMethod: PaymentMethods.BankTransfer),
+                CreateBooking(id: 4, paymentMethod: PaymentMethods.CreditCard),
+            };
+            var service = CreateProcessingService(bookings);
+
+            var bookingsToCapture = await service.GetForCapture(date);
+
+            Assert.DoesNotContain(1, bookingsToCapture);
+            Assert.DoesNotContain(2, bookingsToCapture);
+            Assert.Contains(3, bookingsToCapture);
+            Assert.Contains(4, bookingsToCapture);
+
+            static Booking CreateBooking(int id, PaymentMethods paymentMethod) => new Booking
+            {
+                Id = id, 
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                Status = BookingStatusCodes.Confirmed,
+                PaymentMethod = paymentMethod,
+                DeadlineDate = DateTime.MinValue,
+                CheckInDate = DateTime.MinValue
+            };
+        }
+        
+        
+        [Fact]
+        public async Task Should_return_authorized_bookings()
+        {
+            var date = new DateTime(2021, 12, 2);
+            var bookings = new []
+            {
+                CreateBooking(id: 1, paymentStatus: BookingPaymentStatuses.Authorized),
+                CreateBooking(id: 2, paymentStatus: BookingPaymentStatuses.Captured),
+                CreateBooking(id: 3, paymentStatus: BookingPaymentStatuses.Refunded),
+                CreateBooking(id: 4, paymentStatus: BookingPaymentStatuses.Voided),
+                CreateBooking(id: 5, paymentStatus: BookingPaymentStatuses.NotPaid)
+            };
+            var service = CreateProcessingService(bookings);
+
+            var bookingsToCapture = await service.GetForCapture(date);
+
+            Assert.Contains(1, bookingsToCapture);
+            Assert.DoesNotContain(2, bookingsToCapture);
+            Assert.DoesNotContain(3, bookingsToCapture);
+            Assert.DoesNotContain(4, bookingsToCapture);
+            Assert.DoesNotContain(5, bookingsToCapture);
+
+            static Booking CreateBooking(int id, BookingPaymentStatuses paymentStatus) => new Booking
+            {
+                Id = id, 
+                PaymentStatus = paymentStatus,
+                Status = BookingStatusCodes.Confirmed,
+                PaymentMethod = PaymentMethods.CreditCard,
+                DeadlineDate = DateTime.MinValue,
+                CheckInDate = DateTime.MinValue
+            };
+        }
+
+        
+        [Fact]
+        public async Task Should_return_confirmed_or_pending_bookings()
+        {
+            var date = new DateTime(2021, 12, 2);
+            var bookings = new []
+            {
+                CreateBooking(id: 1, statusCode: BookingStatusCodes.Cancelled),
+                CreateBooking(id: 2, statusCode: BookingStatusCodes.Confirmed),
+                CreateBooking(id: 3, statusCode: BookingStatusCodes.Invalid),
+                CreateBooking(id: 4, statusCode: BookingStatusCodes.Pending),
+                CreateBooking(id: 5, statusCode: BookingStatusCodes.Rejected),
+                CreateBooking(id: 6, statusCode: BookingStatusCodes.InternalProcessing),
+                CreateBooking(id: 7, statusCode: BookingStatusCodes.WaitingForResponse)
+            };
+            var service = CreateProcessingService(bookings);
+
+            var bookingsToCapture = await service.GetForCapture(date);
+
+            Assert.DoesNotContain(1, bookingsToCapture);
+            Assert.Contains(2, bookingsToCapture);
+            Assert.DoesNotContain(3, bookingsToCapture);
+            Assert.Contains(4, bookingsToCapture);
+            Assert.DoesNotContain(5, bookingsToCapture);
+            Assert.Contains(6, bookingsToCapture);
+            Assert.Contains(7, bookingsToCapture);
+
+            static Booking CreateBooking(int id, BookingStatusCodes statusCode) => new Booking
+            {
+                Id = id, 
+                PaymentStatus = BookingPaymentStatuses.Authorized,
+                Status = statusCode,
+                PaymentMethod = PaymentMethods.CreditCard,
+                DeadlineDate = DateTime.MinValue,
+                CheckInDate = DateTime.MinValue
+            };
+        }
+        
+
+        private BookingsProcessingService CreateProcessingService(IEnumerable<Booking> bookings)
+        {
+            var context = MockEdoContext.Create();
+            context.Setup(c => c.Bookings)
+                .Returns(DbSetMockProvider.GetDbSetMock(bookings));
+
+            var service = new BookingsProcessingService(Mock.Of<IBookingPaymentService>(),
+                Mock.Of<IPaymentNotificationService>(),
+                Mock.Of<IBookingService>(),
+                new DefaultDateTimeProvider(),
+                context.Object);
+            
+            return service;
+        }
+    }
+}


### PR DESCRIPTION
Capturing money for bookings that was authorized earlier and deadline or checkin date is came.
Money captures only for bookings that was not rejected or cancelled earlier.