### PR TITLE
Added top-level properties for results ordering

### DIFF
--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -664,6 +664,16 @@
             Accommodation data
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Accommodations.AvailabilityResult.MinPrice">
+            <summary>
+            Minimal room contract set price
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Accommodations.AvailabilityResult.MaxPrice">
+            <summary>
+            Maximal room contract set price
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Accommodations.AvailabilityResult.RoomContractSets">
             <summary>
             List of available room contracts sets

--- a/Api/Models/Accommodations/AvailabilityResult.cs
+++ b/Api/Models/Accommodations/AvailabilityResult.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using HappyTravel.EdoContracts.Accommodations.Internals;
 using Newtonsoft.Json;
 
@@ -8,16 +7,22 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
     public readonly struct AvailabilityResult
     {
         [JsonConstructor]
-        public AvailabilityResult(string availabilityId, SlimAccommodationDetails accommodationDetails, List<RoomContractSet> roomContractSets)
+        public AvailabilityResult(string availabilityId, 
+            SlimAccommodationDetails accommodationDetails,
+            List<RoomContractSet> roomContractSets,
+            decimal minPrice,
+            decimal maxPrice)
         {
             AvailabilityId = availabilityId;
             AccommodationDetails = accommodationDetails;
+            MinPrice = minPrice;
+            MaxPrice = maxPrice;
             RoomContractSets = roomContractSets ?? new List<RoomContractSet>();
         }
 
 
         public AvailabilityResult(AvailabilityResult result, List<RoomContractSet> roomContractSets)
-            : this(result.AvailabilityId, result.AccommodationDetails, roomContractSets)
+            : this(result.AvailabilityId, result.AccommodationDetails, roomContractSets, result.MinPrice, result.MaxPrice)
         { }
         
         /// <summary>
@@ -29,7 +34,17 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         /// Accommodation data
         /// </summary>
         public SlimAccommodationDetails AccommodationDetails { get; }
+
+        /// <summary>
+        /// Minimal room contract set price
+        /// </summary>
+        public decimal MinPrice { get; }
         
+        /// <summary>
+        /// Maximal room contract set price
+        /// </summary>
+        public decimal MaxPrice { get; }
+
         /// <summary>
         /// List of available room contracts sets
         /// </summary>

--- a/Api/Services/Accommodations/Availability/AvailabilityStorage.cs
+++ b/Api/Services/Accommodations/Availability/AvailabilityStorage.cs
@@ -69,11 +69,15 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability
                         var details = providerAvailability.Details;
                         var availabilityResults = details
                             .Results
-                            .Select(r =>
+                            .Select(accommodationAvailability =>
                             {
+                                var minPrice = accommodationAvailability.RoomContractSets.Min(r => r.Price.NetTotal);
+                                var maxPrice = accommodationAvailability.RoomContractSets.Max(r => r.Price.NetTotal);
                                 var result = new AvailabilityResult(providerAvailability.Details.AvailabilityId,
-                                    r.AccommodationDetails,
-                                    r.RoomContractSets);
+                                    accommodationAvailability.AccommodationDetails,
+                                    accommodationAvailability.RoomContractSets,
+                                    minPrice,
+                                    maxPrice);
 
                                 return ProviderData.Create(providerKey, result);
                             })


### PR DESCRIPTION
Use cases:
`{{ edo.baseUrl  }}/en/api/1.0/availabilities/accommodations/searches/e2218df0-fc5d-4f39-8a60-c425a23ff7a9?$top=10&$orderBy=Data/MaxPrice asc` - order by **maximal** price **ascending**

`{{ edo.baseUrl  }}/en/api/1.0/availabilities/accommodations/searches/e2218df0-fc5d-4f39-8a60-c425a23ff7a9?$top=10&$orderBy=Data/MinPrice desc`  - order by **minimal** price **descending**