### PR TITLE
Moved agent methods from admin payments controller

### DIFF
--- a/Api/Controllers/AdministratorControllers/PaymentsController.cs
+++ b/Api/Controllers/AdministratorControllers/PaymentsController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using HappyTravel.Edo.Api.Filters.Authorization.AdministratorFilters;
@@ -12,10 +11,7 @@ using HappyTravel.Money.Enums;
 using HappyTravel.Money.Models;
 using Microsoft.AspNetCore.Mvc;
 using CSharpFunctionalExtensions;
-using HappyTravel.Edo.Api.Filters.Authorization.InAgencyPermissionFilters;
 using HappyTravel.Edo.Api.Models.Users;
-using HappyTravel.Edo.Common.Enums;
-using HappyTravel.EdoContracts.General.Enums;
 
 namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 {
@@ -25,32 +21,12 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
     [Produces("application/json")]
     public class PaymentsController : BaseController
     {
-        public PaymentsController(IAccountPaymentService accountPaymentService, IBookingPaymentService bookingPaymentService,
+        public PaymentsController(IBookingPaymentService bookingPaymentService,
             IAdministratorContext administratorContext, ICounterpartyAccountService counterpartyAccountService)
         {
-            _accountPaymentService = accountPaymentService;
             _bookingPaymentService = bookingPaymentService;
             _administratorContext = administratorContext;
             _counterpartyAccountService = counterpartyAccountService;
-        }
-
-
-        /// <summary>	
-        ///     Appends money to specified account.	
-        /// </summary>	
-        /// <param name="accountId">Id of account to add money.</param>	
-        /// <param name="paymentData">Payment details.</param>	
-        /// <returns></returns>	
-        [HttpPost("{accountId}/replenish")]
-        [ProducesResponseType(typeof(IReadOnlyCollection<PaymentMethods>), (int) HttpStatusCode.NoContent)]
-        [AdministratorPermissions(AdministratorPermissions.AccountReplenish)]
-        public async Task<IActionResult> ReplenishAccount(int accountId, [FromBody] PaymentData paymentData)
-        {
-            var (_, _, administrator, _) = await _administratorContext.GetCurrent();
-            var (isSuccess, _, error) = await _accountPaymentService.ReplenishAccount(accountId, paymentData, administrator);
-            return isSuccess
-                ? NoContent()
-                : (IActionResult) BadRequest(ProblemDetailsBuilder.Build(error));
         }
 
 
@@ -149,27 +125,6 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         }
 
 
-        /// <summary>
-        ///     Transfers money from an agency account to a child agency account
-        /// </summary>
-        /// <param name="payerAccountId">Id of the payer agency account</param>
-        /// <param name="recipientAccountId">Id of the recepient agency account</param>
-        /// <param name="amount">Amount of money to transfer</param>
-        [HttpPost("{payerAccountId}/transfer/{recipientAccountId}")]
-        [ProducesResponseType((int)HttpStatusCode.NoContent)]
-        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
-        [InAgencyPermissions(InAgencyPermissions.AgencyToChildTransfer)]
-        public async Task<IActionResult> TransferToChildAgency(int payerAccountId, int recipientAccountId, [FromBody] MoneyAmount amount)
-        {
-            var (isSuccess, _, error) = await _accountPaymentService.TransferToChildAgency(payerAccountId, recipientAccountId, amount);
-
-            return isSuccess
-                ? NoContent()
-                : (IActionResult)BadRequest(ProblemDetailsBuilder.Build(error));
-        }
-
-
-        private readonly IAccountPaymentService _accountPaymentService;
         private readonly IAdministratorContext _administratorContext;
         private readonly IBookingPaymentService _bookingPaymentService;
         private readonly ICounterpartyAccountService _counterpartyAccountService;

--- a/Api/Controllers/AgentControllers/AgencyAccountsController.cs
+++ b/Api/Controllers/AgentControllers/AgencyAccountsController.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Filters.Authorization.InAgencyPermissionFilters;
+using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Services.Payments.Accounts;
+using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Money.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HappyTravel.Edo.Api.Controllers.AgentControllers
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/{v:apiVersion}/agency-accounts")]
+    [Produces("application/json")]
+    public class AgencyAccountsController : BaseController
+    {
+        public AgencyAccountsController(IAccountPaymentService accountPaymentService)
+        {
+            _accountPaymentService = accountPaymentService;
+        }
+        
+        
+        /// <summary>
+        ///     Transfers money from an agency account to a child agency account
+        /// </summary>
+        /// <param name="payerAccountId">Id of the payer agency account</param>
+        /// <param name="recipientAccountId">Id of the recepient agency account</param>
+        /// <param name="amount">Amount of money to transfer</param>
+        [HttpPost("{payerAccountId}/transfer/{recipientAccountId}")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [InAgencyPermissions(InAgencyPermissions.AgencyToChildTransfer)]
+        public async Task<IActionResult> TransferToChildAgency(int payerAccountId, int recipientAccountId, [FromBody] MoneyAmount amount)
+        {
+            var (isSuccess, _, error) = await _accountPaymentService.TransferToChildAgency(payerAccountId, recipientAccountId, amount);
+
+            return isSuccess
+                ? NoContent()
+                : (IActionResult)BadRequest(ProblemDetailsBuilder.Build(error));
+        }
+        
+        private readonly IAccountPaymentService _accountPaymentService;
+    }
+}

--- a/Api/Services/Payments/Accounts/AccountPaymentService.cs
+++ b/Api/Services/Payments/Accounts/AccountPaymentService.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
-using HappyTravel.Edo.Api.Extensions;
 using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.FunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Agents;
@@ -13,7 +12,6 @@ using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data;
 using HappyTravel.Edo.Data.Booking;
 using HappyTravel.Edo.Data.Infrastructure.DatabaseExtensions;
-using HappyTravel.Edo.Data.Management;
 using HappyTravel.Edo.Data.Payments;
 using HappyTravel.EdoContracts.Accommodations.Enums;
 using HappyTravel.EdoContracts.General;
@@ -121,12 +119,6 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
                     ? Result.Ok($"Payment for the booking '{booking.ReferenceCode}' completed.")
                     : Result.Failure<string>($"Unable to complete payment for the booking '{booking.ReferenceCode}'. Reason: {result.Error}");
         }
-
-
-        public Task<Result> ReplenishAccount(int accountId, PaymentData payment, Administrator administrator)
-            => _accountPaymentProcessingService.AddMoney(accountId,
-                payment,
-                administrator.ToUserInfo());
 
 
         public Task<Result<PaymentResponse>> AuthorizeMoney(AccountBookingPaymentRequest request, AgentContext agentInfo, string ipAddress)

--- a/Api/Services/Payments/Accounts/IAccountPaymentService.cs
+++ b/Api/Services/Payments/Accounts/IAccountPaymentService.cs
@@ -4,7 +4,6 @@ using HappyTravel.Edo.Api.Models.Agents;
 using HappyTravel.Edo.Api.Models.Payments;
 using HappyTravel.Edo.Api.Models.Users;
 using HappyTravel.Edo.Data.Booking;
-using HappyTravel.Edo.Data.Management;
 using HappyTravel.EdoContracts.General;
 using HappyTravel.Money.Enums;
 using HappyTravel.Money.Models;
@@ -13,7 +12,6 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
 {
     public interface IAccountPaymentService
     {
-        Task<Result> ReplenishAccount(int accountId, PaymentData payment, Administrator administrator);
         Task<bool> CanPayWithAccount(AgentContext agentContext);
         Task<Result<AccountBalanceInfo>> GetAccountBalance(Currencies currency);
         Task<Result<string>> CaptureMoney(Booking booking, UserInfo user);


### PR DESCRIPTION
1. Removed adding money to agency account at all. As discussed, there is no way to add money to agency directly, only through counterparty account
2. Moved transfering money to default agency to separate controller. This is not administrator's responsibility