### PR TITLE
Moved getting agent context to controllers for bookings and removed s…

### DIFF
--- a/Api/Controllers/AgentControllers/AccommodationsController.cs
+++ b/Api/Controllers/AgentControllers/AccommodationsController.cs
@@ -199,7 +199,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [InAgencyPermissions(InAgencyPermissions.AccommodationBooking)]
         public async Task<IActionResult> RegisterBooking([FromBody] AccommodationBookingRequest request)
         {
-            var (_, isFailure, refCode, error) = await _bookingService.Register(request, LanguageCode);
+            var (_, isFailure, refCode, error) = await _bookingService.Register(request, await _agentContextService.GetAgent(), LanguageCode);
             if (isFailure)
                 return BadRequest(error);
 
@@ -280,7 +280,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [AgentRequired]
         public async Task<IActionResult> GetBookingById(int bookingId)
         {
-            var (_, isFailure, bookingData, error) = await _bookingRecordsManager.GetAgentBookingInfo(bookingId, LanguageCode);
+            var (_, isFailure, bookingData, error) = await _bookingRecordsManager.GetAgentBookingInfo(bookingId, await _agentContextService.GetAgent(), LanguageCode);
 
             if (isFailure)
                 return BadRequest(error);
@@ -299,7 +299,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [AgentRequired]
         public async Task<IActionResult> GetBookingByReferenceCode(string referenceCode)
         {
-            var (_, isFailure, bookingData, error) = await _bookingRecordsManager.GetAgentBookingInfo(referenceCode, LanguageCode);
+            var (_, isFailure, bookingData, error) = await _bookingRecordsManager.GetAgentBookingInfo(referenceCode, await _agentContextService.GetAgent(), LanguageCode);
 
             if (isFailure)
                 return BadRequest(error);
@@ -318,7 +318,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [AgentRequired]
         public async Task<IActionResult> GetAgentBookings()
         {
-            var (_, isFailure, bookings, error) = await _bookingRecordsManager.GetAgentBookingsInfo();
+            var (_, isFailure, bookings, error) = await _bookingRecordsManager.GetAgentBookingsInfo(await _agentContextService.GetAgent());
             if (isFailure)
                 return BadRequest(error);
 

--- a/Api/Controllers/AgentControllers/AgencyAccountsController.cs
+++ b/Api/Controllers/AgentControllers/AgencyAccountsController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Filters.Authorization.InAgencyPermissionFilters;
 using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Api.Services.Payments.Accounts;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Money.Models;
@@ -16,9 +17,11 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
     [Produces("application/json")]
     public class AgencyAccountsController : BaseController
     {
-        public AgencyAccountsController(IAccountPaymentService accountPaymentService)
+        public AgencyAccountsController(IAccountPaymentService accountPaymentService,
+            IAgentContextService agentContextService)
         {
             _accountPaymentService = accountPaymentService;
+            _agentContextService = agentContextService;
         }
         
         
@@ -34,7 +37,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [InAgencyPermissions(InAgencyPermissions.AgencyToChildTransfer)]
         public async Task<IActionResult> TransferToChildAgency(int payerAccountId, int recipientAccountId, [FromBody] MoneyAmount amount)
         {
-            var (isSuccess, _, error) = await _accountPaymentService.TransferToChildAgency(payerAccountId, recipientAccountId, amount);
+            var (isSuccess, _, error) = await _accountPaymentService.TransferToChildAgency(payerAccountId, recipientAccountId, amount, await _agentContextService.GetAgent());
 
             return isSuccess
                 ? NoContent()
@@ -42,5 +45,6 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         }
         
         private readonly IAccountPaymentService _accountPaymentService;
+        private readonly IAgentContextService _agentContextService;
     }
 }

--- a/Api/Controllers/AgentControllers/PaymentsController.cs
+++ b/Api/Controllers/AgentControllers/PaymentsController.cs
@@ -120,7 +120,10 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [ProducesResponseType(typeof(AccountBalanceInfo), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [InAgencyPermissions(InAgencyPermissions.ObserveBalance)]
-        public Task<IActionResult> GetAccountBalance(Currencies currency) => OkOrBadRequest(_accountPaymentService.GetAccountBalance(currency));
+        public async Task<IActionResult> GetAccountBalance(Currencies currency)
+        {
+            return OkOrBadRequest(await _accountPaymentService.GetAccountBalance(currency, await _agentContextService.GetAgent()));
+        }
 
 
         private readonly IAgentContextService _agentContextService;

--- a/Api/Controllers/AgentControllers/PaymentsController.cs
+++ b/Api/Controllers/AgentControllers/PaymentsController.cs
@@ -66,7 +66,8 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             return OkOrBadRequest(await _creditCardPaymentProcessingService.Authorize(request,
                 LanguageCode,
                 ClientIp,
-                _bookingPaymentService));
+                _bookingPaymentService,
+                await _agentContextService.GetAgent()));
         }
 
 
@@ -83,7 +84,8 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             return OkOrBadRequest(await _creditCardPaymentProcessingService.Authorize(request,
                 LanguageCode,
                 ClientIp,
-                _bookingPaymentService));
+                _bookingPaymentService,
+                await _agentContextService.GetAgent()));
         }
 
 

--- a/Api/Services/Accommodations/Bookings/BookingService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingService.cs
@@ -61,7 +61,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         }
 
         
-        public async Task<Result<string, ProblemDetails>> Register(AccommodationBookingRequest bookingRequest, string languageCode)
+        public async Task<Result<string, ProblemDetails>> Register(AccommodationBookingRequest bookingRequest, AgentContext agentContext, string languageCode)
         {
             var (_, isCachedAvailabilityFailure, responseWithMarkup, cachedAvailabilityError) = await _availabilityResultsCache.Get(bookingRequest.DataProvider, bookingRequest.AvailabilityId);
             if (isCachedAvailabilityFailure)
@@ -69,14 +69,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
             
             var bookingAvailability = ExtractBookingAvailabilityInfo(responseWithMarkup.Data);
             
-            var referenceCode = await _bookingRecordsManager.Register(bookingRequest, bookingAvailability, languageCode);
+            var referenceCode = await _bookingRecordsManager.Register(bookingRequest, bookingAvailability, agentContext, languageCode);
             return Result.Ok<string, ProblemDetails>(referenceCode);
         }
         
         
         public async Task<Result<AccommodationBookingInfo, ProblemDetails>> Finalize(string referenceCode, AgentContext agent, string languageCode)
         {
-            var (_, isFailure, booking, error) = await _bookingRecordsManager.GetAgentsBooking(referenceCode);
+            var (_, isFailure, booking, error) = await _bookingRecordsManager.GetAgentsBooking(referenceCode, agent);
             if (isFailure)
                 return ProblemDetailsBuilder.Fail<AccommodationBookingInfo>(error);
 
@@ -184,7 +184,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
             
             Task<Result<AccommodationBookingInfo, ProblemDetails>> GetBookingInfo(BookingDetails details)
             {
-                return _bookingRecordsManager.GetAgentBookingInfo(details.ReferenceCode, languageCode)
+                return _bookingRecordsManager.GetAgentBookingInfo(details.ReferenceCode, agent, languageCode)
                     .ToResultWithProblemDetails();
             }
         }

--- a/Api/Services/Accommodations/Bookings/IBookingRecordsManager.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingRecordsManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Accommodations;
+using HappyTravel.Edo.Api.Models.Agents;
 using HappyTravel.Edo.Api.Models.Bookings;
 using HappyTravel.Edo.Data.Booking;
 using HappyTravel.EdoContracts.Accommodations;
@@ -10,9 +11,9 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 {
     public interface IBookingRecordsManager
     {
-        Task<Result<AccommodationBookingInfo>> GetAgentBookingInfo(int bookingId, string languageCode);
+        Task<Result<AccommodationBookingInfo>> GetAgentBookingInfo(int bookingId, AgentContext agentContext, string languageCode);
         
-        Task<Result<AccommodationBookingInfo>> GetAgentBookingInfo(string referenceCode, string languageCode);
+        Task<Result<AccommodationBookingInfo>> GetAgentBookingInfo(string referenceCode, AgentContext agentContext, string languageCode);
         
         Task<Result<Booking>> Get(string referenceCode);
         
@@ -20,7 +21,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 
         Task<Result<Booking>> Get(int bookingId, int agentId);
         
-        Task<Result<List<SlimAccommodationBookingInfo>>> GetAgentBookingsInfo();
+        Task<Result<List<SlimAccommodationBookingInfo>>> GetAgentBookingsInfo(AgentContext agentContext);
         
         Task Confirm(BookingDetails bookingDetails, Booking booking);
         
@@ -28,8 +29,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         
         Task UpdateBookingDetails(BookingDetails bookingDetails, Booking booking);
  
-        Task<string> Register(AccommodationBookingRequest bookingRequest, BookingAvailabilityInfo bookingAvailability, string languageCode);
+        Task<string> Register(AccommodationBookingRequest bookingRequest, BookingAvailabilityInfo bookingAvailability, AgentContext agentContext, string languageCode);
 
-        Task<Result<Booking>> GetAgentsBooking(string referenceCode);
+        Task<Result<Booking>> GetAgentsBooking(string referenceCode, AgentContext agentContext);
     }
 }

--- a/Api/Services/Accommodations/Bookings/IBookingService.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingService.cs
@@ -12,7 +12,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 {
     public interface IBookingService
     {
-        Task<Result<string, ProblemDetails>> Register(AccommodationBookingRequest bookingRequest, string languageCode);
+        Task<Result<string, ProblemDetails>> Register(AccommodationBookingRequest bookingRequest, AgentContext agent, string languageCode);
 
         Task<Result<AccommodationBookingInfo, ProblemDetails>> Finalize(string referenceCode, AgentContext agent, string languageCode);
         

--- a/Api/Services/Agents/IAgentContextService.cs
+++ b/Api/Services/Agents/IAgentContextService.cs
@@ -12,8 +12,6 @@ namespace HappyTravel.Edo.Api.Services.Agents
         ValueTask<AgentContext> GetAgent();
 
         Task<List<AgentAgencyInfo>> GetAgentCounterparties();
-        
-        ValueTask<Result<AgentContext>> SetAgentInfo(int agentId);
 
         Task<bool> IsAgentAffiliatedWithCounterparty(int agentId, int counterpartyId);
 

--- a/Api/Services/Payments/Accounts/IAccountPaymentService.cs
+++ b/Api/Services/Payments/Accounts/IAccountPaymentService.cs
@@ -13,11 +13,11 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
     public interface IAccountPaymentService
     {
         Task<bool> CanPayWithAccount(AgentContext agentContext);
-        Task<Result<AccountBalanceInfo>> GetAccountBalance(Currencies currency);
+        Task<Result<AccountBalanceInfo>> GetAccountBalance(Currencies currency, AgentContext agent);
         Task<Result<string>> CaptureMoney(Booking booking, UserInfo user);
         Task<Result<PaymentResponse>> AuthorizeMoney(AccountBookingPaymentRequest request, AgentContext agentContext, string ipAddress);
         Task<Result> VoidMoney(Booking booking, UserInfo user);
         Task<Result<Price>> GetPendingAmount(Booking booking);
-        Task<Result> TransferToChildAgency(int payerAccountId, int recipientAccountId, MoneyAmount amount);
+        Task<Result> TransferToChildAgency(int payerAccountId, int recipientAccountId, MoneyAmount amount, AgentContext agent);
     }
 }

--- a/Api/Services/Payments/CreditCards/CreditCardMoneyAuthorizationService.cs
+++ b/Api/Services/Payments/CreditCards/CreditCardMoneyAuthorizationService.cs
@@ -22,7 +22,7 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
 
         public Task<Result<CreditCardPaymentResult>> ProcessPaymentResponse(CreditCardPaymentResult paymentResponse,
             Currencies currency,
-            AgentContext customer)
+            int agentId)
         {
             return CheckPaymentStatusNotFailed(paymentResponse)
                 .TapIf(IsPaymentComplete, cardPaymentResult => WriteAuditLog());
@@ -36,7 +36,7 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
 
             bool IsPaymentComplete(CreditCardPaymentResult cardPaymentResult) => cardPaymentResult.Status == CreditCardPaymentStatuses.Success;
 
-            Task WriteAuditLog() => WriteAuthorizeAuditLog(paymentResponse, customer, currency);
+            Task WriteAuditLog() => WriteAuthorizeAuditLog(paymentResponse, agentId, currency);
         }
 
 
@@ -59,12 +59,12 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
             }
 
             
-            Task WriteAuditLog(CreditCardPaymentResult result) => WriteAuthorizeAuditLog(result, agent, request.Currency);
+            Task WriteAuditLog(CreditCardPaymentResult result) => WriteAuthorizeAuditLog(result, agent.AgentId, request.Currency);
         }
 
 
 
-        private Task WriteAuthorizeAuditLog(CreditCardPaymentResult payment, AgentContext agent, Currencies currency)
+        private Task WriteAuthorizeAuditLog(CreditCardPaymentResult payment, int agentId, Currencies currency)
         {
             var eventData = new CreditCardLogEventData($"Authorize money for the payment '{payment.ReferenceCode}'",
                 payment.ExternalCode,
@@ -74,10 +74,10 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
             return _creditCardAuditService.Write(CreditCardEventType.Authorize,
                 payment.CardNumber,
                 payment.Amount,
-                new UserInfo(agent.AgentId, UserTypes.Agent),
+                new UserInfo(agentId, UserTypes.Agent),
                 eventData,
                 payment.ReferenceCode,
-                agent.AgentId,
+                agentId,
                 currency);
         }
 

--- a/Api/Services/Payments/CreditCards/CreditCardPaymentService.cs
+++ b/Api/Services/Payments/CreditCards/CreditCardPaymentService.cs
@@ -27,7 +27,6 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
     {
         public CreditCardPaymentProcessingService(IPayfortResponseParser responseParser,
             EdoContext context,
-            IAgentContextService agentContextService,
             ICreditCardsManagementService creditCardsManagementService,
             IEntityLocker locker,
             IDateTimeProvider dateTimeProvider,
@@ -36,7 +35,6 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
         {
             _responseParser = responseParser;
             _context = context;
-            _agentContextService = agentContextService;
             _creditCardsManagementService = creditCardsManagementService;
             _locker = locker;
             _dateTimeProvider = dateTimeProvider;
@@ -46,9 +44,8 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
         
         
         public async Task<Result<PaymentResponse>> Authorize(NewCreditCardPaymentRequest request, 
-            string languageCode, string ipAddress, IPaymentsService paymentsService)
+            string languageCode, string ipAddress, IPaymentsService paymentsService, AgentContext agent)
         {
-            var agent = await _agentContextService.GetAgent();
             var (_, isFailure, servicePrice, error) = await paymentsService.GetServicePrice(request.ReferenceCode);
             if (isFailure)
                 return Result.Failure<PaymentResponse>(error);
@@ -113,9 +110,8 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
         
         
         public async Task<Result<PaymentResponse>> Authorize(SavedCreditCardPaymentRequest request, string languageCode, 
-            string ipAddress, IPaymentsService paymentsService)
+            string ipAddress, IPaymentsService paymentsService, AgentContext agent)
         {
-            var agent = await _agentContextService.GetAgent();
             var (_, isFailure, servicePrice, error) = await paymentsService.GetServicePrice(request.ReferenceCode);
             if (isFailure)
                 return Result.Failure<PaymentResponse>(error);
@@ -238,7 +234,6 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
             
             async Task<Result<(CreditCardPaymentResult, Payment)>> ProcessPaymentResponse()
             {
-                var agent = await _agentContextService.GetAgent();
                 var (_, isFailure, payment, error) = await GetPaymentForResponse(paymentResponse);
                 if (isFailure)
                     return Result.Failure<(CreditCardPaymentResult, Payment)>(error);
@@ -246,10 +241,12 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
                 // Payment can be completed before. Nothing to do now.
                 if (payment.Status == PaymentStatuses.Authorized)
                     return Result.Ok((GetDefaultSuccessResult(), payment));
+
+                var (_, _, serviceBuyer, _) = await paymentsService.GetServiceBuyer(payment.ReferenceCode);
                 
                 var (_, isProcessFailure, processResult, processError) = await _moneyAuthorizationService.ProcessPaymentResponse(paymentResponse,
                     Enum.Parse<Currencies>(payment.Currency),
-                    agent);
+                    serviceBuyer.AgentId);
                 
                 if(isProcessFailure)
                     return Result.Failure<(CreditCardPaymentResult, Payment)>(processError);
@@ -402,7 +399,6 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
 
         private readonly IPayfortResponseParser _responseParser;
         private readonly EdoContext _context;
-        private readonly IAgentContextService _agentContextService;
         private readonly ICreditCardsManagementService _creditCardsManagementService;
         private readonly IEntityLocker _locker;
         private readonly IDateTimeProvider _dateTimeProvider;

--- a/Api/Services/Payments/CreditCards/ICreditCardMoneyAuthorizationService.cs
+++ b/Api/Services/Payments/CreditCards/ICreditCardMoneyAuthorizationService.cs
@@ -10,10 +10,10 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
     {
         Task<Result<CreditCardPaymentResult>> ProcessPaymentResponse(CreditCardPaymentResult paymentResponse,
             Currencies currency,
-            AgentContext customer);
+            int agentId);
 
 
         Task<Result<CreditCardPaymentResult>> AuthorizeMoneyForService(CreditCardPaymentRequest request,
-            AgentContext customer);
+            AgentContext agentContext);
     }
 }

--- a/Api/Services/Payments/CreditCards/ICreditCardPaymentProcessingService.cs
+++ b/Api/Services/Payments/CreditCards/ICreditCardPaymentProcessingService.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Agents;
 using HappyTravel.Edo.Api.Models.Payments;
 using HappyTravel.Edo.Api.Models.Users;
 using Newtonsoft.Json.Linq;
@@ -9,11 +10,11 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
     public interface ICreditCardPaymentProcessingService
     {
         Task<Result<PaymentResponse>> Authorize(NewCreditCardPaymentRequest request, 
-            string languageCode, string ipAddress, IPaymentsService paymentsService);
+            string languageCode, string ipAddress, IPaymentsService paymentsService, AgentContext agent);
 
 
         Task<Result<PaymentResponse>> Authorize(SavedCreditCardPaymentRequest request, string languageCode, 
-            string ipAddress, IPaymentsService paymentsService);
+            string ipAddress, IPaymentsService paymentsService, AgentContext agent);
 
 
         Task<Result<PaymentResponse>> ProcessPaymentResponse(JObject rawResponse, IPaymentsService paymentsService);

--- a/Api/Services/ProviderResponses/BookingWebhookResponseService.cs
+++ b/Api/Services/ProviderResponses/BookingWebhookResponseService.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
-using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Api.Services.Connectors;
 using HappyTravel.Edo.Common.Enums;
 
@@ -14,12 +13,10 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
         public BookingWebhookResponseService(
              IDataProviderFactory dataProviderFactory,
              IBookingRecordsManager bookingRecordsManager,
-             IBookingService bookingService,
-             IAgentContextService agentContextService)
+             IBookingService bookingService)
         {
             _dataProviderFactory = dataProviderFactory;
             _bookingRecordsManager = bookingRecordsManager;
-            _agentContextService = agentContextService;
             _bookingService = bookingService;
         }
         
@@ -39,15 +36,12 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
             if (isGetBookingFailure)
                 return Result.Failure(getBookingError);
             
-            await _agentContextService.SetAgentInfo(booking.AgentId);
-            
             await _bookingService.ProcessResponse(bookingDetails, booking);
             return Result.Ok();
         }
 
         private readonly IDataProviderFactory _dataProviderFactory;
         private readonly IBookingRecordsManager _bookingRecordsManager;
-        private readonly IAgentContextService _agentContextService;
         private readonly IBookingService _bookingService;
         private static readonly List<DataProviders> AsyncDataProviders = new List<DataProviders>{DataProviders.Netstorming, DataProviders.Etg};
     }

--- a/Api/Services/ProviderResponses/NetstormingResponseService.cs
+++ b/Api/Services/ProviderResponses/NetstormingResponseService.cs
@@ -8,9 +8,7 @@ using FloxDc.CacheFlow.Extensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Infrastructure.Logging;
 using HappyTravel.Edo.Api.Infrastructure.Options;
-using HappyTravel.Edo.Api.Services.Accommodations;
 using HappyTravel.Edo.Api.Services.Accommodations.Bookings;
-using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.EdoContracts.Accommodations;
 using HappyTravel.EdoContracts.Accommodations.Enums;
 using Microsoft.Extensions.Logging;
@@ -23,7 +21,6 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
         public NetstormingResponseService(
             IConnectorClient connectorClient,
             IMemoryFlow memoryFlow,
-            IAgentContextService agentContextService,
             IBookingRecordsManager bookingRecordsManager,
             IBookingService bookingService,
             IOptions<DataProviderOptions> dataProviderOptions,
@@ -32,7 +29,6 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
             _connectorClient = connectorClient;
             _dataProviderOptions = dataProviderOptions.Value;
             _memoryFlow = memoryFlow;
-            _agentContextService = agentContextService;
             _bookingRecordsManager = bookingRecordsManager;
             _bookingService = bookingService;
             _logger = logger;
@@ -62,8 +58,6 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
                 _logger.LogWarning(getBookingError);
                 return Result.Failure(getBookingError);
             }
-            
-            await _agentContextService.SetAgentInfo(booking.AgentId);
             
             _logger.LogUnableGetBookingDetailsFromNetstormingXml($"Set {nameof(booking.AgentId)} to '{booking.AgentId}'");
             
@@ -114,7 +108,6 @@ namespace HappyTravel.Edo.Api.Services.ProviderResponses
         private readonly IBookingService _bookingService;
         private readonly DataProviderOptions _dataProviderOptions;
         private readonly IMemoryFlow _memoryFlow;
-        private readonly IAgentContextService _agentContextService;
         private readonly ILogger<NetstormingResponseService> _logger;
         
         private static readonly TimeSpan CacheExpirationPeriod = TimeSpan.FromMinutes(2);

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/CanPayWithAccount.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/CanPayWithAccount.cs
@@ -18,8 +18,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public CanPayWithAccount(Mock<EdoContext> edoContextMock, IDateTimeProvider dateTimeProvider)
         {
             _accountPaymentService = new AccountPaymentService(Mock.Of<IAccountPaymentProcessingService>(), edoContextMock.Object,
-                dateTimeProvider, Mock.Of<IAgentContextService>(),
-                Mock.Of<IAccountManagementService>());
+                dateTimeProvider, Mock.Of<IAccountManagementService>());
 
             edoContextMock
                 .Setup(c => c.PaymentAccounts)


### PR DESCRIPTION
…etting agent context in async response processors

There was a problem:
Because of implicit getting AgentContext deep inside in services some outer services (like async booking response processors) could fail, because request to them does not contain any information about the agent context.

I've moved getting agent context up to controllers for booking services and removed setting this implicit context.