### PR TITLE
Bugfix/nijo 817 validate counterparty approval states

### DIFF
--- a/Api/AdministratorServices/ICounterpartyManagementService.cs
+++ b/Api/AdministratorServices/ICounterpartyManagementService.cs
@@ -22,6 +22,8 @@ namespace HappyTravel.Edo.Api.AdministratorServices
         Task<Result> VerifyAsFullyAccessed(int counterpartyId, string verificationReason);
 
         Task<Result> VerifyAsReadOnly(int counterpartyId, string verificationReason);
+        
+        Task<Result> FailVerification(int counterpartyId, string verificationReason);
 
         Task<Result> DeactivateCounterparty(int counterpartyId);
 

--- a/Api/Controllers/AdministratorControllers/CounterpartiesController.cs
+++ b/Api/Controllers/AdministratorControllers/CounterpartiesController.cs
@@ -63,7 +63,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// <param name="counterpartyId">Id of the counterparty to verify.</param>
         /// <param name="request">Verification details.</param>
         /// <returns></returns>
-        [HttpPost("{counterpartyId}/verify")]
+        [HttpPost("{counterpartyId}/verify/full-access")]
         [ProducesResponseType((int) HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyVerification)]
@@ -90,6 +90,26 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         public async Task<IActionResult> VerifyAsReadOnly(int counterpartyId, [FromBody] CounterpartyVerificationRequest request)
         {
             var (isSuccess, _, error) = await _counterpartyManagementService.VerifyAsReadOnly(counterpartyId, request.Reason);
+
+            return isSuccess
+                ? (IActionResult) NoContent()
+                : BadRequest(ProblemDetailsBuilder.Build(error));
+        }
+        
+        
+        /// <summary>
+        ///     Sets counterparty read-only verified.
+        /// </summary>
+        /// <param name="counterpartyId">Id of the counterparty to verify.</param>
+        /// <param name="request">Verification details.</param>
+        /// <returns></returns>
+        [HttpPost("{counterpartyId}/verify/fail")]
+        [ProducesResponseType((int) HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
+        [AdministratorPermissions(AdministratorPermissions.CounterpartyVerification)]
+        public async Task<IActionResult> FailVerification(int counterpartyId, [FromBody] CounterpartyVerificationRequest request)
+        {
+            var (isSuccess, _, error) = await _counterpartyManagementService.FailVerification(counterpartyId, request.Reason);
 
             return isSuccess
                 ? (IActionResult) NoContent()

--- a/Api/Models/Accommodations/WideAvailabilityResult.cs
+++ b/Api/Models/Accommodations/WideAvailabilityResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using HappyTravel.Edo.Common.Enums;
 using HappyTravel.EdoContracts.Accommodations.Internals;
 using Newtonsoft.Json;
 
@@ -13,19 +14,21 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             List<RoomContractSet> roomContractSets,
             decimal minPrice,
             decimal maxPrice,
-            bool hasDuplicate)
+            bool hasDuplicate,
+            DataProviders dataProvider)
         {
             Id = id;
             AccommodationDetails = accommodationDetails;
             MinPrice = minPrice;
             MaxPrice = maxPrice;
             HasDuplicate = hasDuplicate;
+            DataProvider = dataProvider;
             RoomContractSets = roomContractSets ?? new List<RoomContractSet>();
         }
 
 
         public WideAvailabilityResult(WideAvailabilityResult result, List<RoomContractSet> roomContractSets)
-            : this(result.Id, result.AccommodationDetails, roomContractSets, result.MinPrice, result.MaxPrice, result.HasDuplicate)
+            : this(result.Id, result.AccommodationDetails, roomContractSets, result.MinPrice, result.MaxPrice, result.HasDuplicate, result.DataProvider)
         { }
         
         public Guid Id { get; }
@@ -51,6 +54,13 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         /// </summary>
         public bool HasDuplicate { get; }
 
+        
+        /// <summary>
+        /// Temporarily added data provider for filtering and testing purposes. 
+        /// </summary>
+        public DataProviders DataProvider { get; }
+
+        
         /// <summary>
         /// List of available room contracts sets
         /// </summary>

--- a/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilitySearchService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilitySearchService.cs
@@ -97,7 +97,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                             availability.RoomContractSets,
                             availability.MinPrice,
                             availability.MaxPrice,
-                            hasDuplicatesForCurrentAgent);
+                            hasDuplicatesForCurrentAgent,
+                            provider);
                     });
             }
         }

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/CounterpartyManagementServiceTests/CounterpartyVerificationTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/CounterpartyManagementServiceTests/CounterpartyVerificationTests.cs
@@ -67,6 +67,20 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.CounterpartyMana
             Assert.True(isFailure);
             Assert.True(counterparty.State == CounterpartyStates.PendingVerification);
         }
+        
+        
+        [Fact]
+        public async Task Verification_as_read_only_for_full_accessed_counterparty_should_fail()
+        {
+            var context = _administratorServicesMockCreationHelper.GetContextMock().Object;
+            var counterpartyManagementService = _administratorServicesMockCreationHelper.GetCounterpartyManagementService(context);
+
+            var (_, isFailure, _) = await counterpartyManagementService.VerifyAsReadOnly(14, "Test reason");
+
+            var counterparty = context.Counterparties.Single(c => c.Id == 14);
+            Assert.True(isFailure);
+            Assert.True(counterparty.State == CounterpartyStates.FullAccess);
+        }
 
 
         [Fact]

--- a/HappyTravel.Edo.UnitTests/Utility/AdministratorServicesMockCreationHelper.cs
+++ b/HappyTravel.Edo.UnitTests/Utility/AdministratorServicesMockCreationHelper.cs
@@ -158,7 +158,7 @@ namespace HappyTravel.Edo.UnitTests.Utility
                 Name = "Test",
                 CountryCode = "AF",
                 IsActive = true,
-                State = CounterpartyStates.ReadOnly
+                State = CounterpartyStates.PendingVerification
             },
             new Counterparty
             {


### PR DESCRIPTION
As discussed with @kirillta , valid state changes are:
**PendingVerification->VerifiedReadOnly
VerifiedReadOnly->VerifiedFullAccess
PendingVerification->FailedVerification**

All others should be prohibited.
Additionally, removed one hack, added setting verification in the same transaction where accounts are created