### PR TITLE
Enabled connectors for agent are got from database

### DIFF
--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ using HappyTravel.Edo.Api.Services.Users;
 using HappyTravel.Edo.Api.Services.Versioning;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data;
+using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Geography;
 using HappyTravel.MailSender;
 using HappyTravel.MailSender.Infrastructure;
@@ -498,6 +499,8 @@ namespace HappyTravel.Edo.Api.Infrastructure
 
             services.AddTransient<IAccommodationDuplicatesService, AccommodationDuplicatesService>();
             services.AddTransient<IAccommodationDuplicateReportsManagementService, AccommodationDuplicateReportsManagementService>();
+
+            services.AddTransient<IAgentSystemSettingsService, AgentSystemSettingsService>();
             
             return services;
         }

--- a/Api/Services/Agents/AgentSystemSettingsService.cs
+++ b/Api/Services/Agents/AgentSystemSettingsService.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Data;
+using HappyTravel.Edo.Data.Agents;
+using Microsoft.EntityFrameworkCore;
+
+namespace HappyTravel.Edo.Api.Services.Agents
+{
+    public class AgentSystemSettingsService : IAgentSystemSettingsService
+    {
+        public AgentSystemSettingsService(EdoContext context)
+        {
+            _context = context;
+        }
+        
+        public async Task<AvailabilitySearchSettings?> GetAvailabilitySearchSettings(AgentContext agent)
+        {
+            var settings = await _context
+                .AgentSystemSettings
+                .SingleOrDefaultAsync(s => s.AgentId == agent.AgentId && s.AgencyId == agent.AgencyId);
+
+            return settings?.AvailabilitySearchSettings;
+        }
+        
+        private readonly EdoContext _context;
+    }
+}

--- a/Api/Services/Agents/IAgentSystemSettingsService.cs
+++ b/Api/Services/Agents/IAgentSystemSettingsService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Data.Agents;
+
+namespace HappyTravel.Edo.Api.Services.Agents
+{
+    public interface IAgentSystemSettingsService
+    {
+        public Task<AvailabilitySearchSettings?> GetAvailabilitySearchSettings(AgentContext agent);
+    }
+}

--- a/Api/Services/Connectors/DataProviderManager.cs
+++ b/Api/Services/Connectors/DataProviderManager.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FloxDc.CacheFlow;
+using FloxDc.CacheFlow.Extensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Infrastructure.Options;
 using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Common.Enums;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -15,8 +18,12 @@ namespace HappyTravel.Edo.Api.Services.Connectors
     {
         public DataProviderManager(IOptions<DataProviderOptions> options,
             IConnectorClient connectorClient,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IAgentSystemSettingsService agentSystemSettingsService,
+            IDoubleFlow doubleFlow)
         {
+            _agentSystemSettingsService = agentSystemSettingsService;
+            _doubleFlow = doubleFlow;
             _options = options.Value;
             _dataProviders = new Dictionary<DataProviders, IDataProvider>
             {
@@ -37,16 +44,28 @@ namespace HappyTravel.Edo.Api.Services.Connectors
         }
 
 
-        public async ValueTask<List<DataProviders>> GetEnabled(AgentContext agent)
+        public Task<List<DataProviders>> GetEnabled(AgentContext agent)
         {
-            // TODO: NIJO-874 Get settings from storage per user.
-            return _options.EnabledProviders;
+            var key = _doubleFlow.BuildKey(nameof(DataProviderManager),
+                nameof(GetEnabled),
+                agent.AgentId.ToString(),
+                agent.AgencyId.ToString());
+
+            return _doubleFlow.GetOrSetAsync(key, async () =>
+            {
+                var agentSettings = (await _agentSystemSettingsService.GetAvailabilitySearchSettings(agent))?.EnabledProviders;
+                return agentSettings ?? _options.EnabledProviders;
+            }, AgentEnabledConnectorsCacheLifetime);
         }
 
 
         public IDataProvider Get(DataProviders key) => _dataProviders[key];
 
+        private static readonly TimeSpan AgentEnabledConnectorsCacheLifetime = TimeSpan.FromMinutes(5);
+        
         private readonly Dictionary<DataProviders, IDataProvider> _dataProviders;
+        private readonly IAgentSystemSettingsService _agentSystemSettingsService;
+        private readonly IDoubleFlow _doubleFlow;
         private readonly DataProviderOptions _options;
     }
 }

--- a/Api/Services/Connectors/IDataProviderManager.cs
+++ b/Api/Services/Connectors/IDataProviderManager.cs
@@ -9,6 +9,6 @@ namespace HappyTravel.Edo.Api.Services.Connectors
     {
         IDataProvider Get(DataProviders key);
 
-        ValueTask<List<DataProviders>> GetEnabled(AgentContext agent);
+        Task<List<DataProviders>> GetEnabled(AgentContext agent);
     }
 }

--- a/HappyTravel.Edo.Data/Agents/AgentSystemSettings.cs
+++ b/HappyTravel.Edo.Data/Agents/AgentSystemSettings.cs
@@ -1,0 +1,9 @@
+namespace HappyTravel.Edo.Data.Agents
+{
+    public class AgentSystemSettings
+    {
+        public int AgentId { get; set; }
+        public int AgencyId { get; set; }
+        public AvailabilitySearchSettings AvailabilitySearchSettings { get; set; }
+    }
+}

--- a/HappyTravel.Edo.Data/Agents/AvailabilitySearchSettings.cs
+++ b/HappyTravel.Edo.Data/Agents/AvailabilitySearchSettings.cs
@@ -9,7 +9,7 @@ namespace HappyTravel.Edo.Data.Agents
         [JsonConstructor]
         public AvailabilitySearchSettings(List<DataProviders> enabledProviders)
         {
-            EnabledProviders = enabledProviders;
+            EnabledProviders = enabledProviders ?? new List<DataProviders>();
         }
         
         public List<DataProviders> EnabledProviders { get; }

--- a/HappyTravel.Edo.Data/Agents/AvailabilitySearchSettings.cs
+++ b/HappyTravel.Edo.Data/Agents/AvailabilitySearchSettings.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using HappyTravel.Edo.Common.Enums;
+using Newtonsoft.Json;
+
+namespace HappyTravel.Edo.Data.Agents
+{
+    public readonly struct AvailabilitySearchSettings
+    {
+        [JsonConstructor]
+        public AvailabilitySearchSettings(List<DataProviders> enabledProviders)
+        {
+            EnabledProviders = enabledProviders;
+        }
+        
+        public List<DataProviders> EnabledProviders { get; }
+    }
+}

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -78,6 +78,8 @@ namespace HappyTravel.Edo.Data
         public virtual DbSet<AccommodationDuplicate> AccommodationDuplicates { get; set; }
         
         public virtual DbSet<AccommodationDuplicateReport> AccommodationDuplicateReports { get; set; }
+        
+        public virtual DbSet<AgentSystemSettings> AgentSystemSettings { get; set; }
 
 
         [DbFunction("jsonb_to_string")]
@@ -228,6 +230,7 @@ namespace HappyTravel.Edo.Data
             BuildReceipts(builder);
             BuildAccommodationDuplicates(builder);
             BuildAccommodationDuplicateReports(builder);
+            BuildAgentSystemSettings(builder);
         }
 
 
@@ -745,6 +748,16 @@ namespace HappyTravel.Edo.Data
                 
                 duplicate.HasIndex(r => r.ReporterAgentId);
                 duplicate.Property(r => r.Accommodations).HasColumnType("jsonb");
+            });
+        }
+        
+        
+        private void BuildAgentSystemSettings(ModelBuilder builder)
+        {
+            builder.Entity<AgentSystemSettings>(settings =>
+            {
+                settings.HasKey(r => new { r.AgentId, r.AgencyId });
+                settings.Property(r => r.AvailabilitySearchSettings).HasColumnType("jsonb");
             });
         }
         

--- a/HappyTravel.Edo.Data/Migrations/20200902143136_AgentSystemSettingsTable.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20200902143136_AgentSystemSettingsTable.Designer.cs
@@ -7,6 +7,7 @@ using HappyTravel.Edo.Data.AccommodationMappings;
 using HappyTravel.Edo.Data.Agents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -14,9 +15,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20200902143136_AgentSystemSettingsTable")]
+    partial class AgentSystemSettingsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20200902143136_AgentSystemSettingsTable.cs
+++ b/HappyTravel.Edo.Data/Migrations/20200902143136_AgentSystemSettingsTable.cs
@@ -1,0 +1,30 @@
+﻿using HappyTravel.Edo.Data.Agents;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class AgentSystemSettingsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AgentSystemSettings",
+                columns: table => new
+                {
+                    AgentId = table.Column<int>(nullable: false),
+                    AgencyId = table.Column<int>(nullable: false),
+                    AvailabilitySearchSettings = table.Column<AvailabilitySearchSettings>(type: "jsonb", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AgentSystemSettings", x => new { x.AgentId, x.AgencyId });
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AgentSystemSettings");
+        }
+    }
+}


### PR DESCRIPTION
This is the second part.
We do have separate setting for each agent for enabled connectors.
In this PR there is no API to set it by admin, this will be added soon or maybe much later.
For now we can adjust it for only one user (Denis) in database by hand.

What this is needed for?
We urgently need to enable Illusions connector on prod, just for one user, for testing.