### PR TITLE
Removed returning booking details from refresh-status endpoint

### DIFF
--- a/Api/Controllers/AgentControllers/AccommodationsController.cs
+++ b/Api/Controllers/AgentControllers/AccommodationsController.cs
@@ -294,17 +294,17 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         /// <param name="bookingId">Id of the booking</param>
         /// <returns>Updated booking details.</returns>
         [HttpPost("accommodations/bookings/{bookingId}/refresh-status")]
-        [ProducesResponseType(typeof(Booking), (int) HttpStatusCode.OK)]
+        [ProducesResponseType((int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [MinCounterpartyState(CounterpartyStates.FullAccess)]
         [InAgencyPermissions(InAgencyPermissions.AccommodationBooking)]
         public async Task<IActionResult> RefreshStatus([FromRoute] int bookingId)
         {
-            var (_, isFailure, bookingDetails, error) = await _bookingManagementService.RefreshStatus(bookingId);
+            var (_, isFailure, _, error) = await _bookingManagementService.RefreshStatus(bookingId);
             if (isFailure)
                 return BadRequest(error);
 
-            return Ok(bookingDetails);
+            return Ok();
         }
 
 

--- a/Api/Services/Accommodations/Bookings/BookingManagementService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingManagementService.cs
@@ -66,7 +66,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
         }
 
 
-        public async Task<Result<Booking, ProblemDetails>> RefreshStatus(int bookingId)
+        public async Task<Result<VoidObject, ProblemDetails>> RefreshStatus(int bookingId)
         {
             var (_, isGetBookingFailure, booking, getBookingError) = await _bookingRecordsManager.Get(bookingId);
             if (isGetBookingFailure)
@@ -74,7 +74,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
                 _logger.LogBookingRefreshStatusFailure(
                     $"Failed to refresh status for a booking with id {bookingId} while getting the booking. Error: {getBookingError}");
                 
-                return ProblemDetailsBuilder.Fail<Booking>(getBookingError);
+                return ProblemDetailsBuilder.Fail<VoidObject>(getBookingError);
             }
 
             var oldStatus = booking.Status;
@@ -88,7 +88,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
                 _logger.LogBookingRefreshStatusFailure($"Failed to refresh status for a booking with reference code: '{referenceCode}' " +
                     $"while getting info from a provider. Error: {getBookingError}");
                 
-                return Result.Failure<Booking, ProblemDetails>(getDetailsError);
+                return Result.Failure<VoidObject, ProblemDetails>(getDetailsError);
             }
 
             await _responseProcessor.ProcessResponse(newDetails, booking);
@@ -96,7 +96,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
             _logger.LogBookingRefreshStatusSuccess($"Successfully refreshed status fot a booking with reference code: '{referenceCode}'. " +
                 $"Old status: {oldStatus}. New status: {newDetails.Status}");
 
-            return Result.Success<Booking, ProblemDetails>(newDetails);
+            return VoidObject.Instance;
         }
 
 

--- a/Api/Services/Accommodations/Bookings/IBookingManagementService.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingManagementService.cs
@@ -3,7 +3,6 @@ using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure.DataProviders;
 using HappyTravel.Edo.Api.Models.Agents;
 using HappyTravel.Edo.Data.Management;
-using HappyTravel.EdoContracts.Accommodations;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
@@ -16,6 +15,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
 
         Task<Result<VoidObject, ProblemDetails>> Cancel(int bookingId, Administrator administrator, bool requireProviderConfirmation);
         
-        Task<Result<Booking, ProblemDetails>> RefreshStatus(int bookingId);
+        Task<Result<VoidObject, ProblemDetails>> RefreshStatus(int bookingId);
     }
 }


### PR DESCRIPTION
The fronted does not use these details anymore